### PR TITLE
feat: #11 チェックボックス情報の登録編集機能を追加する

### DIFF
--- a/dist/taskit.html
+++ b/dist/taskit.html
@@ -1,0 +1,3296 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taskit.js</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+    </style>
+    <script type="module" crossorigin>(function(){const r=document.createElement("link").relList;if(r&&r.supports&&r.supports("modulepreload"))return;for(const l of document.querySelectorAll('link[rel="modulepreload"]'))i(l);new MutationObserver(l=>{for(const c of l)if(c.type==="childList")for(const h of c.addedNodes)h.tagName==="LINK"&&h.rel==="modulepreload"&&i(h)}).observe(document,{childList:!0,subtree:!0});function o(l){const c={};return l.integrity&&(c.integrity=l.integrity),l.referrerPolicy&&(c.referrerPolicy=l.referrerPolicy),l.crossOrigin==="use-credentials"?c.credentials="include":l.crossOrigin==="anonymous"?c.credentials="omit":c.credentials="same-origin",c}function i(l){if(l.ep)return;l.ep=!0;const c=o(l);fetch(l.href,c)}})();const Xn=globalThis,Oi=Xn.ShadowRoot&&(Xn.ShadyCSS===void 0||Xn.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,Pi=Symbol(),Os=new WeakMap;let pa=class{constructor(r,o,i){if(this._$cssResult$=!0,i!==Pi)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=r,this.t=o}get styleSheet(){let r=this.o;const o=this.t;if(Oi&&r===void 0){const i=o!==void 0&&o.length===1;i&&(r=Os.get(o)),r===void 0&&((this.o=r=new CSSStyleSheet).replaceSync(this.cssText),i&&Os.set(o,r))}return r}toString(){return this.cssText}};const Ae=t=>new pa(typeof t=="string"?t:t+"",void 0,Pi),ct=(t,...r)=>{const o=t.length===1?t[0]:r.reduce((i,l,c)=>i+(h=>{if(h._$cssResult$===!0)return h.cssText;if(typeof h=="number")return h;throw Error("Value passed to 'css' function must be a 'css' function result: "+h+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(l)+t[c+1],t[0]);return new pa(o,t,Pi)},xl=(t,r)=>{if(Oi)t.adoptedStyleSheets=r.map(o=>o instanceof CSSStyleSheet?o:o.styleSheet);else for(const o of r){const i=document.createElement("style"),l=Xn.litNonce;l!==void 0&&i.setAttribute("nonce",l),i.textContent=o.cssText,t.appendChild(i)}},Ps=Oi?t=>t:t=>t instanceof CSSStyleSheet?(r=>{let o="";for(const i of r.cssRules)o+=i.cssText;return Ae(o)})(t):t;const{is:kl,defineProperty:Cl,getOwnPropertyDescriptor:$l,getOwnPropertyNames:Al,getOwnPropertySymbols:Sl,getPrototypeOf:El}=Object,Ie=globalThis,zs=Ie.trustedTypes,Tl=zs?zs.emptyScript:"",Ol=Ie.reactiveElementPolyfillSupport,nn=(t,r)=>t,xr={toAttribute(t,r){switch(r){case Boolean:t=t?Tl:null;break;case Object:case Array:t=t==null?t:JSON.stringify(t)}return t},fromAttribute(t,r){let o=t;switch(r){case Boolean:o=t!==null;break;case Number:o=t===null?null:Number(t);break;case Object:case Array:try{o=JSON.parse(t)}catch{o=null}}return o}},zi=(t,r)=>!kl(t,r),Ms={attribute:!0,type:String,converter:xr,reflect:!1,useDefault:!1,hasChanged:zi};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),Ie.litPropertyMetadata??(Ie.litPropertyMetadata=new WeakMap);let yr=class extends HTMLElement{static addInitializer(r){this._$Ei(),(this.l??(this.l=[])).push(r)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(r,o=Ms){if(o.state&&(o.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(r)&&((o=Object.create(o)).wrapped=!0),this.elementProperties.set(r,o),!o.noAccessor){const i=Symbol(),l=this.getPropertyDescriptor(r,i,o);l!==void 0&&Cl(this.prototype,r,l)}}static getPropertyDescriptor(r,o,i){const{get:l,set:c}=$l(this.prototype,r)??{get(){return this[o]},set(h){this[o]=h}};return{get:l,set(h){const m=l?.call(this);c?.call(this,h),this.requestUpdate(r,m,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(r){return this.elementProperties.get(r)??Ms}static _$Ei(){if(this.hasOwnProperty(nn("elementProperties")))return;const r=El(this);r.finalize(),r.l!==void 0&&(this.l=[...r.l]),this.elementProperties=new Map(r.elementProperties)}static finalize(){if(this.hasOwnProperty(nn("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(nn("properties"))){const o=this.properties,i=[...Al(o),...Sl(o)];for(const l of i)this.createProperty(l,o[l])}const r=this[Symbol.metadata];if(r!==null){const o=litPropertyMetadata.get(r);if(o!==void 0)for(const[i,l]of o)this.elementProperties.set(i,l)}this._$Eh=new Map;for(const[o,i]of this.elementProperties){const l=this._$Eu(o,i);l!==void 0&&this._$Eh.set(l,o)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(r){const o=[];if(Array.isArray(r)){const i=new Set(r.flat(1/0).reverse());for(const l of i)o.unshift(Ps(l))}else r!==void 0&&o.push(Ps(r));return o}static _$Eu(r,o){const i=o.attribute;return i===!1?void 0:typeof i=="string"?i:typeof r=="string"?r.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(r=>this.enableUpdating=r),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(r=>r(this))}addController(r){(this._$EO??(this._$EO=new Set)).add(r),this.renderRoot!==void 0&&this.isConnected&&r.hostConnected?.()}removeController(r){this._$EO?.delete(r)}_$E_(){const r=new Map,o=this.constructor.elementProperties;for(const i of o.keys())this.hasOwnProperty(i)&&(r.set(i,this[i]),delete this[i]);r.size>0&&(this._$Ep=r)}createRenderRoot(){const r=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return xl(r,this.constructor.elementStyles),r}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(r=>r.hostConnected?.())}enableUpdating(r){}disconnectedCallback(){this._$EO?.forEach(r=>r.hostDisconnected?.())}attributeChangedCallback(r,o,i){this._$AK(r,i)}_$ET(r,o){const i=this.constructor.elementProperties.get(r),l=this.constructor._$Eu(r,i);if(l!==void 0&&i.reflect===!0){const c=(i.converter?.toAttribute!==void 0?i.converter:xr).toAttribute(o,i.type);this._$Em=r,c==null?this.removeAttribute(l):this.setAttribute(l,c),this._$Em=null}}_$AK(r,o){const i=this.constructor,l=i._$Eh.get(r);if(l!==void 0&&this._$Em!==l){const c=i.getPropertyOptions(l),h=typeof c.converter=="function"?{fromAttribute:c.converter}:c.converter?.fromAttribute!==void 0?c.converter:xr;this._$Em=l;const m=h.fromAttribute(o,c.type);this[l]=m??this._$Ej?.get(l)??m,this._$Em=null}}requestUpdate(r,o,i,l=!1,c){if(r!==void 0){const h=this.constructor;if(l===!1&&(c=this[r]),i??(i=h.getPropertyOptions(r)),!((i.hasChanged??zi)(c,o)||i.useDefault&&i.reflect&&c===this._$Ej?.get(r)&&!this.hasAttribute(h._$Eu(r,i))))return;this.C(r,o,i)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(r,o,{useDefault:i,reflect:l,wrapped:c},h){i&&!(this._$Ej??(this._$Ej=new Map)).has(r)&&(this._$Ej.set(r,h??o??this[r]),c!==!0||h!==void 0)||(this._$AL.has(r)||(this.hasUpdated||i||(o=void 0),this._$AL.set(r,o)),l===!0&&this._$Em!==r&&(this._$Eq??(this._$Eq=new Set)).add(r))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(o){Promise.reject(o)}const r=this.scheduleUpdate();return r!=null&&await r,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(const[l,c]of this._$Ep)this[l]=c;this._$Ep=void 0}const i=this.constructor.elementProperties;if(i.size>0)for(const[l,c]of i){const{wrapped:h}=c,m=this[l];h!==!0||this._$AL.has(l)||m===void 0||this.C(l,void 0,c,m)}}let r=!1;const o=this._$AL;try{r=this.shouldUpdate(o),r?(this.willUpdate(o),this._$EO?.forEach(i=>i.hostUpdate?.()),this.update(o)):this._$EM()}catch(i){throw r=!1,this._$EM(),i}r&&this._$AE(o)}willUpdate(r){}_$AE(r){this._$EO?.forEach(o=>o.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(r)),this.updated(r)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(r){return!0}update(r){this._$Eq&&(this._$Eq=this._$Eq.forEach(o=>this._$ET(o,this[o]))),this._$EM()}updated(r){}firstUpdated(r){}};yr.elementStyles=[],yr.shadowRootOptions={mode:"open"},yr[nn("elementProperties")]=new Map,yr[nn("finalized")]=new Map,Ol?.({ReactiveElement:yr}),(Ie.reactiveElementVersions??(Ie.reactiveElementVersions=[])).push("2.1.2");const on=globalThis,Ds=t=>t,eo=on.trustedTypes,Rs=eo?eo.createPolicy("lit-html",{createHTML:t=>t}):void 0,fa="$lit$",Re=`lit$${Math.random().toFixed(9).slice(2)}$`,ba="?"+Re,Pl=`<${ba}>`,sr=document,un=()=>sr.createComment(""),cn=t=>t===null||typeof t!="object"&&typeof t!="function",Mi=Array.isArray,zl=t=>Mi(t)||typeof t?.[Symbol.iterator]=="function",di=`[ 	
+\f\r]`,Yr=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Bs=/-->/g,Is=/>/g,rr=RegExp(`>|${di}(?:([^\\s"'>=/]+)(${di}*=${di}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),Ls=/'/g,Fs=/"/g,ma=/^(?:script|style|textarea|title)$/i,Ml=t=>(r,...o)=>({_$litType$:t,strings:r,values:o}),X=Ml(1),ne=Symbol.for("lit-noChange"),xt=Symbol.for("lit-nothing"),Vs=new WeakMap,ir=sr.createTreeWalker(sr,129);function va(t,r){if(!Mi(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return Rs!==void 0?Rs.createHTML(r):r}const Dl=(t,r)=>{const o=t.length-1,i=[];let l,c=r===2?"<svg>":r===3?"<math>":"",h=Yr;for(let m=0;m<o;m++){const k=t[m];let O,D,P=-1,F=0;for(;F<k.length&&(h.lastIndex=F,D=h.exec(k),D!==null);)F=h.lastIndex,h===Yr?D[1]==="!--"?h=Bs:D[1]!==void 0?h=Is:D[2]!==void 0?(ma.test(D[2])&&(l=RegExp("</"+D[2],"g")),h=rr):D[3]!==void 0&&(h=rr):h===rr?D[0]===">"?(h=l??Yr,P=-1):D[1]===void 0?P=-2:(P=h.lastIndex-D[2].length,O=D[1],h=D[3]===void 0?rr:D[3]==='"'?Fs:Ls):h===Fs||h===Ls?h=rr:h===Bs||h===Is?h=Yr:(h=rr,l=void 0);const R=h===rr&&t[m+1].startsWith("/>")?" ":"";c+=h===Yr?k+Pl:P>=0?(i.push(O),k.slice(0,P)+fa+k.slice(P)+Re+R):k+Re+(P===-2?m:R)}return[va(t,c+(t[o]||"<?>")+(r===2?"</svg>":r===3?"</math>":"")),i]};class dn{constructor({strings:r,_$litType$:o},i){let l;this.parts=[];let c=0,h=0;const m=r.length-1,k=this.parts,[O,D]=Dl(r,o);if(this.el=dn.createElement(O,i),ir.currentNode=this.el.content,o===2||o===3){const P=this.el.content.firstChild;P.replaceWith(...P.childNodes)}for(;(l=ir.nextNode())!==null&&k.length<m;){if(l.nodeType===1){if(l.hasAttributes())for(const P of l.getAttributeNames())if(P.endsWith(fa)){const F=D[h++],R=l.getAttribute(P).split(Re),N=/([.?@])?(.*)/.exec(F);k.push({type:1,index:c,name:N[2],strings:R,ctor:N[1]==="."?Bl:N[1]==="?"?Il:N[1]==="@"?Ll:po}),l.removeAttribute(P)}else P.startsWith(Re)&&(k.push({type:6,index:c}),l.removeAttribute(P));if(ma.test(l.tagName)){const P=l.textContent.split(Re),F=P.length-1;if(F>0){l.textContent=eo?eo.emptyScript:"";for(let R=0;R<F;R++)l.append(P[R],un()),ir.nextNode(),k.push({type:2,index:++c});l.append(P[F],un())}}}else if(l.nodeType===8)if(l.data===ba)k.push({type:2,index:c});else{let P=-1;for(;(P=l.data.indexOf(Re,P+1))!==-1;)k.push({type:7,index:c}),P+=Re.length-1}c++}}static createElement(r,o){const i=sr.createElement("template");return i.innerHTML=r,i}}function kr(t,r,o=t,i){if(r===ne)return r;let l=i!==void 0?o._$Co?.[i]:o._$Cl;const c=cn(r)?void 0:r._$litDirective$;return l?.constructor!==c&&(l?._$AO?.(!1),c===void 0?l=void 0:(l=new c(t),l._$AT(t,o,i)),i!==void 0?(o._$Co??(o._$Co=[]))[i]=l:o._$Cl=l),l!==void 0&&(r=kr(t,l._$AS(t,r.values),l,i)),r}class Rl{constructor(r,o){this._$AV=[],this._$AN=void 0,this._$AD=r,this._$AM=o}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(r){const{el:{content:o},parts:i}=this._$AD,l=(r?.creationScope??sr).importNode(o,!0);ir.currentNode=l;let c=ir.nextNode(),h=0,m=0,k=i[0];for(;k!==void 0;){if(h===k.index){let O;k.type===2?O=new Er(c,c.nextSibling,this,r):k.type===1?O=new k.ctor(c,k.name,k.strings,this,r):k.type===6&&(O=new Fl(c,this,r)),this._$AV.push(O),k=i[++m]}h!==k?.index&&(c=ir.nextNode(),h++)}return ir.currentNode=sr,l}p(r){let o=0;for(const i of this._$AV)i!==void 0&&(i.strings!==void 0?(i._$AI(r,i,o),o+=i.strings.length-2):i._$AI(r[o])),o++}}class Er{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(r,o,i,l){this.type=2,this._$AH=xt,this._$AN=void 0,this._$AA=r,this._$AB=o,this._$AM=i,this.options=l,this._$Cv=l?.isConnected??!0}get parentNode(){let r=this._$AA.parentNode;const o=this._$AM;return o!==void 0&&r?.nodeType===11&&(r=o.parentNode),r}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(r,o=this){r=kr(this,r,o),cn(r)?r===xt||r==null||r===""?(this._$AH!==xt&&this._$AR(),this._$AH=xt):r!==this._$AH&&r!==ne&&this._(r):r._$litType$!==void 0?this.$(r):r.nodeType!==void 0?this.T(r):zl(r)?this.k(r):this._(r)}O(r){return this._$AA.parentNode.insertBefore(r,this._$AB)}T(r){this._$AH!==r&&(this._$AR(),this._$AH=this.O(r))}_(r){this._$AH!==xt&&cn(this._$AH)?this._$AA.nextSibling.data=r:this.T(sr.createTextNode(r)),this._$AH=r}$(r){const{values:o,_$litType$:i}=r,l=typeof i=="number"?this._$AC(r):(i.el===void 0&&(i.el=dn.createElement(va(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===l)this._$AH.p(o);else{const c=new Rl(l,this),h=c.u(this.options);c.p(o),this.T(h),this._$AH=c}}_$AC(r){let o=Vs.get(r.strings);return o===void 0&&Vs.set(r.strings,o=new dn(r)),o}k(r){Mi(this._$AH)||(this._$AH=[],this._$AR());const o=this._$AH;let i,l=0;for(const c of r)l===o.length?o.push(i=new Er(this.O(un()),this.O(un()),this,this.options)):i=o[l],i._$AI(c),l++;l<o.length&&(this._$AR(i&&i._$AB.nextSibling,l),o.length=l)}_$AR(r=this._$AA.nextSibling,o){for(this._$AP?.(!1,!0,o);r!==this._$AB;){const i=Ds(r).nextSibling;Ds(r).remove(),r=i}}setConnected(r){this._$AM===void 0&&(this._$Cv=r,this._$AP?.(r))}}class po{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(r,o,i,l,c){this.type=1,this._$AH=xt,this._$AN=void 0,this.element=r,this.name=o,this._$AM=l,this.options=c,i.length>2||i[0]!==""||i[1]!==""?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=xt}_$AI(r,o=this,i,l){const c=this.strings;let h=!1;if(c===void 0)r=kr(this,r,o,0),h=!cn(r)||r!==this._$AH&&r!==ne,h&&(this._$AH=r);else{const m=r;let k,O;for(r=c[0],k=0;k<c.length-1;k++)O=kr(this,m[i+k],o,k),O===ne&&(O=this._$AH[k]),h||(h=!cn(O)||O!==this._$AH[k]),O===xt?r=xt:r!==xt&&(r+=(O??"")+c[k+1]),this._$AH[k]=O}h&&!l&&this.j(r)}j(r){r===xt?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,r??"")}}class Bl extends po{constructor(){super(...arguments),this.type=3}j(r){this.element[this.name]=r===xt?void 0:r}}class Il extends po{constructor(){super(...arguments),this.type=4}j(r){this.element.toggleAttribute(this.name,!!r&&r!==xt)}}class Ll extends po{constructor(r,o,i,l,c){super(r,o,i,l,c),this.type=5}_$AI(r,o=this){if((r=kr(this,r,o,0)??xt)===ne)return;const i=this._$AH,l=r===xt&&i!==xt||r.capture!==i.capture||r.once!==i.once||r.passive!==i.passive,c=r!==xt&&(i===xt||l);l&&this.element.removeEventListener(this.name,this,i),c&&this.element.addEventListener(this.name,this,r),this._$AH=r}handleEvent(r){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,r):this._$AH.handleEvent(r)}}class Fl{constructor(r,o,i){this.element=r,this.type=6,this._$AN=void 0,this._$AM=o,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(r){kr(this,r)}}const Vl={I:Er},Nl=on.litHtmlPolyfillSupport;Nl?.(dn,Er),(on.litHtmlVersions??(on.litHtmlVersions=[])).push("3.3.2");const ql=(t,r,o)=>{const i=o?.renderBefore??r;let l=i._$litPart$;if(l===void 0){const c=o?.renderBefore??null;i._$litPart$=l=new Er(r.insertBefore(un(),c),c,void 0,o??{})}return l._$AI(t),l};const sn=globalThis;let ae=class extends yr{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var o;const r=super.createRenderRoot();return(o=this.renderOptions).renderBefore??(o.renderBefore=r.firstChild),r}update(r){const o=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(r),this._$Do=ql(o,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return ne}};ae._$litElement$=!0,ae.finalized=!0,sn.litElementHydrateSupport?.({LitElement:ae});const jl=sn.litElementPolyfillSupport;jl?.({LitElement:ae});(sn.litElementVersions??(sn.litElementVersions=[])).push("4.2.2");const Tr=t=>(r,o)=>{o!==void 0?o.addInitializer(()=>{customElements.define(t,r)}):customElements.define(t,r)};const Kl={attribute:!0,type:String,converter:xr,reflect:!1,hasChanged:zi},Hl=(t=Kl,r,o)=>{const{kind:i,metadata:l}=o;let c=globalThis.litPropertyMetadata.get(l);if(c===void 0&&globalThis.litPropertyMetadata.set(l,c=new Map),i==="setter"&&((t=Object.create(t)).wrapped=!0),c.set(o.name,t),i==="accessor"){const{name:h}=o;return{set(m){const k=r.get.call(this);r.set.call(this,m),this.requestUpdate(h,k,t,!0,m)},init(m){return m!==void 0&&this.C(h,void 0,t,m),m}}}if(i==="setter"){const{name:h}=o;return function(m){const k=this[h];r.call(this,m),this.requestUpdate(h,k,t,!0,m)}}throw Error("Unsupported decorator location: "+i)};function C(t){return(r,o)=>typeof o=="object"?Hl(t,r,o):((i,l,c)=>{const h=l.hasOwnProperty(c);return l.constructor.createProperty(c,i),h?Object.getOwnPropertyDescriptor(l,c):void 0})(t,r,o)}function _t(t){return C({...t,state:!0,attribute:!1})}function Ul(t){return(r,o)=>{const i=typeof r=="function"?r:r[o];Object.assign(i,t)}}const Wl=(t,r,o)=>(o.configurable=!0,o.enumerable=!0,Reflect.decorate&&typeof r!="object"&&Object.defineProperty(t,r,o),o);function st(t,r){return(o,i,l)=>{const c=h=>h.renderRoot?.querySelector(t)??null;return Wl(o,i,{get(){return c(this)}})}}var _i="";function Le(t){_i=t}function Gl(t=""){if(!_i){const r=[...document.getElementsByTagName("script")],o=r.find(i=>i.hasAttribute("data-shoelace"));if(o)Le(o.getAttribute("data-shoelace"));else{const i=r.find(c=>/shoelace(\.min)?\.js($|\?)/.test(c.src)||/shoelace-autoloader(\.min)?\.js($|\?)/.test(c.src));let l="";i&&(l=i.getAttribute("src")),Le(l.split("/").slice(0,-1).join("/"))}}return _i.replace(/\/$/,"")+(t?`/${t.replace(/^\//,"")}`:"")}var ga=Object.defineProperty,Yl=Object.defineProperties,Xl=Object.getOwnPropertyDescriptor,Ql=Object.getOwnPropertyDescriptors,Ns=Object.getOwnPropertySymbols,Zl=Object.prototype.hasOwnProperty,Jl=Object.prototype.propertyIsEnumerable,hi=(t,r)=>(r=Symbol[t])?r:Symbol.for("Symbol."+t),Di=t=>{throw TypeError(t)},qs=(t,r,o)=>r in t?ga(t,r,{enumerable:!0,configurable:!0,writable:!0,value:o}):t[r]=o,je=(t,r)=>{for(var o in r||(r={}))Zl.call(r,o)&&qs(t,o,r[o]);if(Ns)for(var o of Ns(r))Jl.call(r,o)&&qs(t,o,r[o]);return t},fo=(t,r)=>Yl(t,Ql(r)),f=(t,r,o,i)=>{for(var l=i>1?void 0:i?Xl(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&ga(r,o,l),l},ya=(t,r,o)=>r.has(t)||Di("Cannot "+o),tu=(t,r,o)=>(ya(t,r,"read from private field"),r.get(t)),eu=(t,r,o)=>r.has(t)?Di("Cannot add the same private member more than once"):r instanceof WeakSet?r.add(t):r.set(t,o),ru=(t,r,o,i)=>(ya(t,r,"write to private field"),r.set(t,o),o),nu=function(t,r){this[0]=t,this[1]=r},ou=t=>{var r=t[hi("asyncIterator")],o=!1,i,l={};return r==null?(r=t[hi("iterator")](),i=c=>l[c]=h=>r[c](h)):(r=r.call(t),i=c=>l[c]=h=>{if(o){if(o=!1,c==="throw")throw h;return h}return o=!0,{done:!1,value:new nu(new Promise(m=>{var k=r[c](h);k instanceof Object||Di("Object expected"),m(k)}),1)}}),l[hi("iterator")]=()=>l,i("next"),"throw"in r?i("throw"):l.throw=c=>{throw c},"return"in r&&i("return"),l},iu={name:"default",resolver:t=>Gl(`assets/icons/${t}.svg`)},su=iu,js={caret:`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="6 9 12 15 18 9"></polyline>
+    </svg>
+  `,check:`
+    <svg part="checked-icon" class="checkbox__icon" viewBox="0 0 16 16">
+      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g stroke="currentColor">
+          <g transform="translate(3.428571, 3.428571)">
+            <path d="M0,5.71428571 L3.42857143,9.14285714"></path>
+            <path d="M9.14285714,0 L3.42857143,9.14285714"></path>
+          </g>
+        </g>
+      </g>
+    </svg>
+  `,"chevron-down":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,"chevron-left":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+    </svg>
+  `,"chevron-right":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  `,copy:`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-copy" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V2Zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H6ZM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1H2Z"/>
+    </svg>
+  `,eye:`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+      <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
+      <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
+    </svg>
+  `,"eye-slash":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
+      <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486l.708.709z"/>
+      <path d="M11.297 9.176a3.5 3.5 0 0 0-4.474-4.474l.823.823a2.5 2.5 0 0 1 2.829 2.829l.822.822zm-2.943 1.299.822.822a3.5 3.5 0 0 1-4.474-4.474l.823.823a2.5 2.5 0 0 0 2.829 2.829z"/>
+      <path d="M3.35 5.47c-.18.16-.353.322-.518.487A13.134 13.134 0 0 0 1.172 8l.195.288c.335.48.83 1.12 1.465 1.755C4.121 11.332 5.881 12.5 8 12.5c.716 0 1.39-.133 2.02-.36l.77.772A7.029 7.029 0 0 1 8 13.5C3 13.5 0 8 0 8s.939-1.721 2.641-3.238l.708.709zm10.296 8.884-12-12 .708-.708 12 12-.708.708z"/>
+    </svg>
+  `,eyedropper:`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eyedropper" viewBox="0 0 16 16">
+      <path d="M13.354.646a1.207 1.207 0 0 0-1.708 0L8.5 3.793l-.646-.647a.5.5 0 1 0-.708.708L8.293 5l-7.147 7.146A.5.5 0 0 0 1 12.5v1.793l-.854.853a.5.5 0 1 0 .708.707L1.707 15H3.5a.5.5 0 0 0 .354-.146L11 7.707l1.146 1.147a.5.5 0 0 0 .708-.708l-.647-.646 3.147-3.146a1.207 1.207 0 0 0 0-1.708l-2-2zM2 12.707l7-7L10.293 7l-7 7H2v-1.293z"></path>
+    </svg>
+  `,"grip-vertical":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-grip-vertical" viewBox="0 0 16 16">
+      <path d="M7 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path>
+    </svg>
+  `,indeterminate:`
+    <svg part="indeterminate-icon" class="checkbox__icon" viewBox="0 0 16 16">
+      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g stroke="currentColor" stroke-width="2">
+          <g transform="translate(2.285714, 6.857143)">
+            <path d="M10.2857143,1.14285714 L1.14285714,1.14285714"></path>
+          </g>
+        </g>
+      </g>
+    </svg>
+  `,"person-fill":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-fill" viewBox="0 0 16 16">
+      <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+    </svg>
+  `,"play-fill":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+      <path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393z"></path>
+    </svg>
+  `,"pause-fill":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pause-fill" viewBox="0 0 16 16">
+      <path d="M5.5 3.5A1.5 1.5 0 0 1 7 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5zm5 0A1.5 1.5 0 0 1 12 5v6a1.5 1.5 0 0 1-3 0V5a1.5 1.5 0 0 1 1.5-1.5z"></path>
+    </svg>
+  `,radio:`
+    <svg part="checked-icon" class="radio__icon" viewBox="0 0 16 16">
+      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g fill="currentColor">
+          <circle cx="8" cy="8" r="3.42857143"></circle>
+        </g>
+      </g>
+    </svg>
+  `,"star-fill":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-star-fill" viewBox="0 0 16 16">
+      <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z"/>
+    </svg>
+  `,"x-lg":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
+      <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
+    </svg>
+  `,"x-circle-fill":`
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle-fill" viewBox="0 0 16 16">
+      <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"></path>
+    </svg>
+  `},au={name:"system",resolver:t=>t in js?`data:image/svg+xml,${encodeURIComponent(js[t])}`:""},lu=au,ro=[su,lu],no=[];function uu(t){no.push(t)}function cu(t){no=no.filter(r=>r!==t)}function Ks(t){return ro.find(r=>r.name===t)}function du(t,r){hu(t),ro.push({name:t,resolver:r.resolver,mutator:r.mutator,spriteSheet:r.spriteSheet}),no.forEach(o=>{o.library===t&&o.setIcon()})}function hu(t){ro=ro.filter(r=>r.name!==t)}const pu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-building" viewBox="0 0 16 16">\r
+  <path d="M4 2.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3.5-.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zM4 5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zM7.5 5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zm2.5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zM4.5 8a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zm2.5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3.5-.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5z"/>\r
+  <path d="M2 1a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1zm11 0H3v14h3v-2.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5V15h3z"/>\r
+</svg>`,fu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-square" viewBox="0 0 16 16">\r
+  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>\r
+  <path d="M10.97 4.97a.75.75 0 0 1 1.071 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425z"/>\r
+</svg>`,bu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar" viewBox="0 0 16 16">\r
+  <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5M1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4z"/>\r
+</svg>`,mu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-card-text" viewBox="0 0 16 16">\r
+  <path d="M14.5 3a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2z"/>\r
+  <path d="M3 5.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5M3 8a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 8m0 2.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5"/>\r
+</svg>`,vu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-left-text" viewBox="0 0 16 16">\r
+  <path d="M14 1a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H4.414A2 2 0 0 0 3 11.586l-2 2V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12.793a.5.5 0 0 0 .854.353l2.853-2.853A1 1 0 0 1 4.414 12H14a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>\r
+  <path d="M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5M3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6m0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5"/>\r
+</svg>`,gu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-copy" viewBox="0 0 16 16">\r
+  <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"/>\r
+</svg>`,yu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-circle-fill" viewBox="0 0 16 16">\r
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M4.5 7.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1z"/>\r
+</svg>`,wu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-square-fill" viewBox="0 0 16 16">\r
+  <path d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm6 4c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995A.905.905 0 0 1 8 4m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>\r
+</svg>`,_u=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-floppy" viewBox="0 0 16 16">\r
+  <path d="M11 2H9v3h2z"/>\r
+  <path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0M1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5m3 4a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1H4zM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5z"/>\r
+</svg>`,xu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-folder" viewBox="0 0 16 16">\r
+  <path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a2 2 0 0 1 .342-1.31zM2.19 4a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 13.81 4zm4.69-1.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139q.323-.119.684-.12h5.396z"/>\r
+</svg>`,ku=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-globe" viewBox="0 0 16 16">\r
+  <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m7.5-6.923c-.67.204-1.335.82-1.887 1.855A8 8 0 0 0 5.145 4H7.5zM4.09 4a9.3 9.3 0 0 1 .64-1.539 7 7 0 0 1 .597-.933A7.03 7.03 0 0 0 2.255 4zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a7 7 0 0 0-.656 2.5zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5zM8.5 5v2.5h2.99a12.5 12.5 0 0 0-.337-2.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5zM5.145 12q.208.58.468 1.068c.552 1.035 1.218 1.65 1.887 1.855V12zm.182 2.472a7 7 0 0 1-.597-.933A9.3 9.3 0 0 1 4.09 12H2.255a7 7 0 0 0 3.072 2.472M3.82 11a13.7 13.7 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5zm6.853 3.472A7 7 0 0 0 13.745 12H11.91a9.3 9.3 0 0 1-.64 1.539 7 7 0 0 1-.597.933M8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855q.26-.487.468-1.068zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.7 13.7 0 0 1-.312 2.5m2.802-3.5a7 7 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7 7 0 0 0-3.072-2.472c.218.284.418.598.597.933M10.855 4a8 8 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4z"/>\r
+</svg>`,Cu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-journal-plus" viewBox="0 0 16 16">\r
+  <path fill-rule="evenodd" d="M8 5.5a.5.5 0 0 1 .5.5v1.5H10a.5.5 0 0 1 0 1H8.5V10a.5.5 0 0 1-1 0V8.5H6a.5.5 0 0 1 0-1h1.5V6a.5.5 0 0 1 .5-.5"/>\r
+  <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2"/>\r
+  <path d="M1 5v-.5a.5.5 0 0 1 1 0V5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0V8h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1zm0 3v-.5a.5.5 0 0 1 1 0v.5h.5a.5.5 0 0 1 0 1h-2a.5.5 0 0 1 0-1z"/>\r
+</svg>`,$u=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">\r
+  <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0"/>\r
+  <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"/>\r
+</svg>`,Au=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people" viewBox="0 0 16 16">\r
+  <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1zm-7.978-1L7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002-.014.002zM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4m3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0M6.936 9.28a6 6 0 0 0-1.23-.247A7 7 0 0 0 5 9c-4 0-5 3-5 4q0 1 1 1h4.216A2.24 2.24 0 0 1 5 13c0-1.01.377-2.042 1.09-2.904.243-.294.526-.569.846-.816M4.92 10A5.5 5.5 0 0 0 4 13H1c0-.26.164-1.03.76-1.724.545-.636 1.492-1.256 3.16-1.275ZM1.5 5.5a3 3 0 1 1 6 0 3 3 0 0 1-6 0m3-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4"/>\r
+</svg>`,Su=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">\r
+  <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>\r
+  <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"/>\r
+</svg>`,Eu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-circle-fill" viewBox="0 0 16 16">\r
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814z"/>\r
+</svg>`,Tu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-lg" viewBox="0 0 16 16">\r
+  <path fill-rule="evenodd" d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2"/>\r
+</svg>`,Ou=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-square" viewBox="0 0 16 16">\r
+  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>\r
+  <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>\r
+</svg>`,Pu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-square" viewBox="0 0 16 16">\r
+  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>\r
+</svg>`,zu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-square-half" viewBox="0 0 16 16">\r
+  <path d="M8 15V1h6a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1zm6 1a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z"/>\r
+</svg>`,Mu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-telephone" viewBox="0 0 16 16">\r
+  <path d="M3.654 1.328a.678.678 0 0 0-1.015-.063L1.605 2.3c-.483.484-.661 1.169-.45 1.77a17.6 17.6 0 0 0 4.168 6.608 17.6 17.6 0 0 0 6.608 4.168c.601.211 1.286.033 1.77-.45l1.034-1.034a.678.678 0 0 0-.063-1.015l-2.307-1.794a.68.68 0 0 0-.58-.122l-2.19.547a1.75 1.75 0 0 1-1.657-.459L5.482 8.062a1.75 1.75 0 0 1-.46-1.657l.548-2.19a.68.68 0 0 0-.122-.58zM1.884.511a1.745 1.745 0 0 1 2.612.163L6.29 2.98c.329.423.445.974.315 1.494l-.547 2.19a.68.68 0 0 0 .178.643l2.457 2.457a.68.68 0 0 0 .644.178l2.189-.547a1.75 1.75 0 0 1 1.494.315l2.306 1.794c.829.645.905 1.87.163 2.611l-1.034 1.034c-.74.74-1.846 1.065-2.877.702a18.6 18.6 0 0 1-7.01-4.42 18.6 18.6 0 0 1-4.42-7.009c-.362-1.03-.037-2.137.703-2.877z"/>\r
+</svg>`,Du=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash3" viewBox="0 0 16 16">\r
+  <path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5M11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1zm1.958 1-.846 10.58a1 1 0 0 1-.997.92h-6.23a1 1 0 0 1-.997-.92L3.042 3.5zm-7.487 1a.5.5 0 0 1 .528.47l.5 8.5a.5.5 0 0 1-.998.06L5 5.03a.5.5 0 0 1 .47-.53Zm5.058 0a.5.5 0 0 1 .47.53l-.5 8.5a.5.5 0 1 1-.998-.06l.5-8.5a.5.5 0 0 1 .528-.47M8 4.5a.5.5 0 0 1 .5.5v8.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5"/>\r
+</svg>`,Ru=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-ui-checks-grid" viewBox="0 0 16 16">\r
+  <path d="M2 10h3a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1m9-9h3a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-3a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1m0 9a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1zm0-10a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h3a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM2 9a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h3a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2zm7 2a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-3a2 2 0 0 1-2-2zM0 2a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm5.354.854a.5.5 0 1 0-.708-.708L3 3.793l-.646-.647a.5.5 0 1 0-.708.708l1 1a.5.5 0 0 0 .708 0z"/>\r
+</svg>`,Bu=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">\r
+  <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>\r
+</svg>`,Hs={building:pu,"check-square":fu,calendar:bu,"card-text":mu,"chat-left-text":vu,copy:gu,"dash-circle-fill":yu,"exclamation-square-fill":wu,floppy:_u,folder:xu,globe:ku,"person-circle":$u,"journal-plus":Cu,people:Au,"pencil-square":Su,"play-circle-fill":Eu,"plus-lg":Tu,"plus-square":Ou,square:Pu,"square-half":zu,telephone:Mu,trash3:Du,"ui-checks-grid":Ru,"chevron-right":Bu},Iu='.container{display:grid;grid-template-columns:320px 1fr 1fr;grid-template-rows:40px minmax(0,1fr) 20px;grid-auto-columns:1fr;grid-auto-rows:1fr;gap:var(--sl-spacing-2x-small) var(--sl-spacing-x-small);grid-auto-flow:row;grid-template-areas:"header-area header-area header-area" "menu-area contents1-area contents2-area" "footer-area footer-area footer-area";height:100vh}.container .header-area{grid-area:header-area;background-color:#3f9aae}.container .menu-area{grid-area:menu-area;overflow:hidden}.container .contents1-area{grid-area:contents1-area;overflow:hidden}.container .contents2-area{grid-area:contents2-area;background-color:#f96e5b;overflow:hidden}.container .footer-area{grid-area:footer-area;background-color:#f96e5b}';var Lu=ct`
+  :host {
+    --track-width: 2px;
+    --track-color: rgb(128 128 128 / 25%);
+    --indicator-color: var(--sl-color-primary-600);
+    --speed: 2s;
+
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+    flex: none;
+  }
+
+  .spinner {
+    flex: 1 1 auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .spinner__track,
+  .spinner__indicator {
+    fill: none;
+    stroke-width: var(--track-width);
+    r: calc(0.5em - var(--track-width) / 2);
+    cx: 0.5em;
+    cy: 0.5em;
+    transform-origin: 50% 50%;
+  }
+
+  .spinner__track {
+    stroke: var(--track-color);
+    transform-origin: 0% 0%;
+  }
+
+  .spinner__indicator {
+    stroke: var(--indicator-color);
+    stroke-linecap: round;
+    stroke-dasharray: 150% 75%;
+    animation: spin var(--speed) linear infinite;
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+      stroke-dasharray: 0.05em, 3em;
+    }
+
+    50% {
+      transform: rotate(450deg);
+      stroke-dasharray: 1.375em, 1.375em;
+    }
+
+    100% {
+      transform: rotate(1080deg);
+      stroke-dasharray: 0.05em, 3em;
+    }
+  }
+`;const xi=new Set,wr=new Map;let or,Ri="ltr",Bi="en";const wa=typeof MutationObserver<"u"&&typeof document<"u"&&typeof document.documentElement<"u";if(wa){const t=new MutationObserver(xa);Ri=document.documentElement.dir||"ltr",Bi=document.documentElement.lang||navigator.language,t.observe(document.documentElement,{attributes:!0,attributeFilter:["dir","lang"]})}function _a(...t){t.map(r=>{const o=r.$code.toLowerCase();wr.has(o)?wr.set(o,Object.assign(Object.assign({},wr.get(o)),r)):wr.set(o,r),or||(or=r)}),xa()}function xa(){wa&&(Ri=document.documentElement.dir||"ltr",Bi=document.documentElement.lang||navigator.language),[...xi.keys()].map(t=>{typeof t.requestUpdate=="function"&&t.requestUpdate()})}let Fu=class{constructor(r){this.host=r,this.host.addController(this)}hostConnected(){xi.add(this.host)}hostDisconnected(){xi.delete(this.host)}dir(){return`${this.host.dir||Ri}`.toLowerCase()}lang(){return`${this.host.lang||Bi}`.toLowerCase()}getTranslationData(r){var o,i;const l=new Intl.Locale(r.replace(/_/g,"-")),c=l?.language.toLowerCase(),h=(i=(o=l?.region)===null||o===void 0?void 0:o.toLowerCase())!==null&&i!==void 0?i:"",m=wr.get(`${c}-${h}`),k=wr.get(c);return{locale:l,language:c,region:h,primary:m,secondary:k}}exists(r,o){var i;const{primary:l,secondary:c}=this.getTranslationData((i=o.lang)!==null&&i!==void 0?i:this.lang());return o=Object.assign({includeFallback:!1},o),!!(l&&l[r]||c&&c[r]||o.includeFallback&&or&&or[r])}term(r,...o){const{primary:i,secondary:l}=this.getTranslationData(this.lang());let c;if(i&&i[r])c=i[r];else if(l&&l[r])c=l[r];else if(or&&or[r])c=or[r];else return console.error(`No translation found for: ${String(r)}`),String(r);return typeof c=="function"?c(...o):c}date(r,o){return r=new Date(r),new Intl.DateTimeFormat(this.lang(),o).format(r)}number(r,o){return r=Number(r),isNaN(r)?"":new Intl.NumberFormat(this.lang(),o).format(r)}relativeTime(r,o,i){return new Intl.RelativeTimeFormat(this.lang(),i).format(r,o)}};var ka={$code:"en",$name:"English",$dir:"ltr",carousel:"Carousel",clearEntry:"Clear entry",close:"Close",copied:"Copied",copy:"Copy",currentValue:"Current value",error:"Error",goToSlide:(t,r)=>`Go to slide ${t} of ${r}`,hidePassword:"Hide password",loading:"Loading",nextSlide:"Next slide",numOptionsSelected:t=>t===0?"No options selected":t===1?"1 option selected":`${t} options selected`,previousSlide:"Previous slide",progress:"Progress",remove:"Remove",resize:"Resize",scrollToEnd:"Scroll to end",scrollToStart:"Scroll to start",selectAColorFromTheScreen:"Select a color from the screen",showPassword:"Show password",slideNum:t=>`Slide ${t}`,toggleColorFormat:"Toggle color format"};_a(ka);var Vu=ka,ve=class extends Fu{};_a(Vu);var St=ct`
+  :host {
+    box-sizing: border-box;
+  }
+
+  :host *,
+  :host *::before,
+  :host *::after {
+    box-sizing: inherit;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+`,Qn,gt=class extends ae{constructor(){super(),eu(this,Qn,!1),this.initialReflectedProperties=new Map,Object.entries(this.constructor.dependencies).forEach(([t,r])=>{this.constructor.define(t,r)})}emit(t,r){const o=new CustomEvent(t,je({bubbles:!0,cancelable:!1,composed:!0,detail:{}},r));return this.dispatchEvent(o),o}static define(t,r=this,o={}){const i=customElements.get(t);if(!i){try{customElements.define(t,r,o)}catch{customElements.define(t,class extends r{},o)}return}let l=" (unknown version)",c=l;"version"in r&&r.version&&(l=" v"+r.version),"version"in i&&i.version&&(c=" v"+i.version),!(l&&c&&l===c)&&console.warn(`Attempted to register <${t}>${l}, but <${t}>${c} has already been registered.`)}attributeChangedCallback(t,r,o){tu(this,Qn)||(this.constructor.elementProperties.forEach((i,l)=>{i.reflect&&this[l]!=null&&this.initialReflectedProperties.set(l,this[l])}),ru(this,Qn,!0)),super.attributeChangedCallback(t,r,o)}willUpdate(t){super.willUpdate(t),this.initialReflectedProperties.forEach((r,o)=>{t.has(o)&&this[o]==null&&(this[o]=r)})}};Qn=new WeakMap;gt.version="2.20.1";gt.dependencies={};f([C()],gt.prototype,"dir",2);f([C()],gt.prototype,"lang",2);var Ii=class extends gt{constructor(){super(...arguments),this.localize=new ve(this)}render(){return X`
+      <svg part="base" class="spinner" role="progressbar" aria-label=${this.localize.term("loading")}>
+        <circle class="spinner__track"></circle>
+        <circle class="spinner__indicator"></circle>
+      </svg>
+    `}};Ii.styles=[St,Lu];var Xr=new WeakMap,Qr=new WeakMap,Zr=new WeakMap,pi=new WeakSet,Wn=new WeakMap,bn=class{constructor(t,r){this.handleFormData=o=>{const i=this.options.disabled(this.host),l=this.options.name(this.host),c=this.options.value(this.host),h=this.host.tagName.toLowerCase()==="sl-button";this.host.isConnected&&!i&&!h&&typeof l=="string"&&l.length>0&&typeof c<"u"&&(Array.isArray(c)?c.forEach(m=>{o.formData.append(l,m.toString())}):o.formData.append(l,c.toString()))},this.handleFormSubmit=o=>{var i;const l=this.options.disabled(this.host),c=this.options.reportValidity;this.form&&!this.form.noValidate&&((i=Xr.get(this.form))==null||i.forEach(h=>{this.setUserInteracted(h,!0)})),this.form&&!this.form.noValidate&&!l&&!c(this.host)&&(o.preventDefault(),o.stopImmediatePropagation())},this.handleFormReset=()=>{this.options.setValue(this.host,this.options.defaultValue(this.host)),this.setUserInteracted(this.host,!1),Wn.set(this.host,[])},this.handleInteraction=o=>{const i=Wn.get(this.host);i.includes(o.type)||i.push(o.type),i.length===this.options.assumeInteractionOn.length&&this.setUserInteracted(this.host,!0)},this.checkFormValidity=()=>{if(this.form&&!this.form.noValidate){const o=this.form.querySelectorAll("*");for(const i of o)if(typeof i.checkValidity=="function"&&!i.checkValidity())return!1}return!0},this.reportFormValidity=()=>{if(this.form&&!this.form.noValidate){const o=this.form.querySelectorAll("*");for(const i of o)if(typeof i.reportValidity=="function"&&!i.reportValidity())return!1}return!0},(this.host=t).addController(this),this.options=je({form:o=>{const i=o.form;if(i){const c=o.getRootNode().querySelector(`#${i}`);if(c)return c}return o.closest("form")},name:o=>o.name,value:o=>o.value,defaultValue:o=>o.defaultValue,disabled:o=>{var i;return(i=o.disabled)!=null?i:!1},reportValidity:o=>typeof o.reportValidity=="function"?o.reportValidity():!0,checkValidity:o=>typeof o.checkValidity=="function"?o.checkValidity():!0,setValue:(o,i)=>o.value=i,assumeInteractionOn:["sl-input"]},r)}hostConnected(){const t=this.options.form(this.host);t&&this.attachForm(t),Wn.set(this.host,[]),this.options.assumeInteractionOn.forEach(r=>{this.host.addEventListener(r,this.handleInteraction)})}hostDisconnected(){this.detachForm(),Wn.delete(this.host),this.options.assumeInteractionOn.forEach(t=>{this.host.removeEventListener(t,this.handleInteraction)})}hostUpdated(){const t=this.options.form(this.host);t||this.detachForm(),t&&this.form!==t&&(this.detachForm(),this.attachForm(t)),this.host.hasUpdated&&this.setValidity(this.host.validity.valid)}attachForm(t){t?(this.form=t,Xr.has(this.form)?Xr.get(this.form).add(this.host):Xr.set(this.form,new Set([this.host])),this.form.addEventListener("formdata",this.handleFormData),this.form.addEventListener("submit",this.handleFormSubmit),this.form.addEventListener("reset",this.handleFormReset),Qr.has(this.form)||(Qr.set(this.form,this.form.reportValidity),this.form.reportValidity=()=>this.reportFormValidity()),Zr.has(this.form)||(Zr.set(this.form,this.form.checkValidity),this.form.checkValidity=()=>this.checkFormValidity())):this.form=void 0}detachForm(){if(!this.form)return;const t=Xr.get(this.form);t&&(t.delete(this.host),t.size<=0&&(this.form.removeEventListener("formdata",this.handleFormData),this.form.removeEventListener("submit",this.handleFormSubmit),this.form.removeEventListener("reset",this.handleFormReset),Qr.has(this.form)&&(this.form.reportValidity=Qr.get(this.form),Qr.delete(this.form)),Zr.has(this.form)&&(this.form.checkValidity=Zr.get(this.form),Zr.delete(this.form)),this.form=void 0))}setUserInteracted(t,r){r?pi.add(t):pi.delete(t),t.requestUpdate()}doAction(t,r){if(this.form){const o=document.createElement("button");o.type=t,o.style.position="absolute",o.style.width="0",o.style.height="0",o.style.clipPath="inset(50%)",o.style.overflow="hidden",o.style.whiteSpace="nowrap",r&&(o.name=r.name,o.value=r.value,["formaction","formenctype","formmethod","formnovalidate","formtarget"].forEach(i=>{r.hasAttribute(i)&&o.setAttribute(i,r.getAttribute(i))})),this.form.append(o),o.click(),o.remove()}}getForm(){var t;return(t=this.form)!=null?t:null}reset(t){this.doAction("reset",t)}submit(t){this.doAction("submit",t)}setValidity(t){const r=this.host,o=!!pi.has(r),i=!!r.required;r.toggleAttribute("data-required",i),r.toggleAttribute("data-optional",!i),r.toggleAttribute("data-invalid",!t),r.toggleAttribute("data-valid",t),r.toggleAttribute("data-user-invalid",!t&&o),r.toggleAttribute("data-user-valid",t&&o)}updateValidity(){const t=this.host;this.setValidity(t.validity.valid)}emitInvalidEvent(t){const r=new CustomEvent("sl-invalid",{bubbles:!1,composed:!1,cancelable:!0,detail:{}});t||r.preventDefault(),this.host.dispatchEvent(r)||t?.preventDefault()}},bo=Object.freeze({badInput:!1,customError:!1,patternMismatch:!1,rangeOverflow:!1,rangeUnderflow:!1,stepMismatch:!1,tooLong:!1,tooShort:!1,typeMismatch:!1,valid:!0,valueMissing:!1}),Nu=Object.freeze(fo(je({},bo),{valid:!1,valueMissing:!0})),qu=Object.freeze(fo(je({},bo),{valid:!1,customError:!0})),Ca=ct`
+  :host {
+    display: inline-block;
+    position: relative;
+    width: auto;
+    cursor: pointer;
+  }
+
+  .button {
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: center;
+    width: 100%;
+    border-style: solid;
+    border-width: var(--sl-input-border-width);
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-font-weight-semibold);
+    text-decoration: none;
+    user-select: none;
+    -webkit-user-select: none;
+    white-space: nowrap;
+    vertical-align: middle;
+    padding: 0;
+    transition:
+      var(--sl-transition-x-fast) background-color,
+      var(--sl-transition-x-fast) color,
+      var(--sl-transition-x-fast) border,
+      var(--sl-transition-x-fast) box-shadow;
+    cursor: inherit;
+  }
+
+  .button::-moz-focus-inner {
+    border: 0;
+  }
+
+  .button:focus {
+    outline: none;
+  }
+
+  .button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* When disabled, prevent mouse events from bubbling up from children */
+  .button--disabled * {
+    pointer-events: none;
+  }
+
+  .button__prefix,
+  .button__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+  }
+
+  .button__label {
+    display: inline-block;
+  }
+
+  .button__label::slotted(sl-icon) {
+    vertical-align: -2px;
+  }
+
+  /*
+   * Standard buttons
+   */
+
+  /* Default */
+  .button--standard.button--default {
+    background-color: var(--sl-color-neutral-0);
+    border-color: var(--sl-input-border-color);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--standard.button--default:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-50);
+    border-color: var(--sl-color-primary-300);
+    color: var(--sl-color-primary-700);
+  }
+
+  .button--standard.button--default:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-100);
+    border-color: var(--sl-color-primary-400);
+    color: var(--sl-color-primary-700);
+  }
+
+  /* Primary */
+  .button--standard.button--primary {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:hover:not(.button--disabled) {
+    background-color: var(--sl-color-primary-500);
+    border-color: var(--sl-color-primary-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--primary:active:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--standard.button--success {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:hover:not(.button--disabled) {
+    background-color: var(--sl-color-success-500);
+    border-color: var(--sl-color-success-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--success:active:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--standard.button--neutral {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:hover:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-500);
+    border-color: var(--sl-color-neutral-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--neutral:active:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--standard.button--warning {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+  .button--standard.button--warning:hover:not(.button--disabled) {
+    background-color: var(--sl-color-warning-500);
+    border-color: var(--sl-color-warning-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--warning:active:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--standard.button--danger {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:hover:not(.button--disabled) {
+    background-color: var(--sl-color-danger-500);
+    border-color: var(--sl-color-danger-500);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--standard.button--danger:active:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /*
+   * Outline buttons
+   */
+
+  .button--outline {
+    background: none;
+    border: solid 1px;
+  }
+
+  /* Default */
+  .button--outline.button--default {
+    border-color: var(--sl-input-border-color);
+    color: var(--sl-color-neutral-700);
+  }
+
+  .button--outline.button--default:hover:not(.button--disabled),
+  .button--outline.button--default.button--checked:not(.button--disabled) {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--default:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Primary */
+  .button--outline.button--primary {
+    border-color: var(--sl-color-primary-600);
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--outline.button--primary:hover:not(.button--disabled),
+  .button--outline.button--primary.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--primary:active:not(.button--disabled) {
+    border-color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-primary-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Success */
+  .button--outline.button--success {
+    border-color: var(--sl-color-success-600);
+    color: var(--sl-color-success-600);
+  }
+
+  .button--outline.button--success:hover:not(.button--disabled),
+  .button--outline.button--success.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-success-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--success:active:not(.button--disabled) {
+    border-color: var(--sl-color-success-700);
+    background-color: var(--sl-color-success-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Neutral */
+  .button--outline.button--neutral {
+    border-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-600);
+  }
+
+  .button--outline.button--neutral:hover:not(.button--disabled),
+  .button--outline.button--neutral.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-neutral-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--neutral:active:not(.button--disabled) {
+    border-color: var(--sl-color-neutral-700);
+    background-color: var(--sl-color-neutral-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Warning */
+  .button--outline.button--warning {
+    border-color: var(--sl-color-warning-600);
+    color: var(--sl-color-warning-600);
+  }
+
+  .button--outline.button--warning:hover:not(.button--disabled),
+  .button--outline.button--warning.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-warning-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--warning:active:not(.button--disabled) {
+    border-color: var(--sl-color-warning-700);
+    background-color: var(--sl-color-warning-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  /* Danger */
+  .button--outline.button--danger {
+    border-color: var(--sl-color-danger-600);
+    color: var(--sl-color-danger-600);
+  }
+
+  .button--outline.button--danger:hover:not(.button--disabled),
+  .button--outline.button--danger.button--checked:not(.button--disabled) {
+    background-color: var(--sl-color-danger-600);
+    color: var(--sl-color-neutral-0);
+  }
+
+  .button--outline.button--danger:active:not(.button--disabled) {
+    border-color: var(--sl-color-danger-700);
+    background-color: var(--sl-color-danger-700);
+    color: var(--sl-color-neutral-0);
+  }
+
+  @media (forced-colors: active) {
+    .button.button--outline.button--checked:not(.button--disabled) {
+      outline: solid 2px transparent;
+    }
+  }
+
+  /*
+   * Text buttons
+   */
+
+  .button--text {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-600);
+  }
+
+  .button--text:hover:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:focus-visible:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-500);
+  }
+
+  .button--text:active:not(.button--disabled) {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--sl-color-primary-700);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .button--small {
+    height: auto;
+    min-height: var(--sl-input-height-small);
+    font-size: var(--sl-button-font-size-small);
+    line-height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-small);
+  }
+
+  .button--medium {
+    height: auto;
+    min-height: var(--sl-input-height-medium);
+    font-size: var(--sl-button-font-size-medium);
+    line-height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-medium);
+  }
+
+  .button--large {
+    height: auto;
+    min-height: var(--sl-input-height-large);
+    font-size: var(--sl-button-font-size-large);
+    line-height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    border-radius: var(--sl-input-border-radius-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .button--pill.button--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .button--pill.button--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .button--pill.button--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Circle modifier
+   */
+
+  .button--circle {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .button--circle.button--small {
+    width: var(--sl-input-height-small);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--medium {
+    width: var(--sl-input-height-medium);
+    border-radius: 50%;
+  }
+
+  .button--circle.button--large {
+    width: var(--sl-input-height-large);
+    border-radius: 50%;
+  }
+
+  .button--circle .button__prefix,
+  .button--circle .button__suffix,
+  .button--circle .button__caret {
+    display: none;
+  }
+
+  /*
+   * Caret modifier
+   */
+
+  .button--caret .button__suffix {
+    display: none;
+  }
+
+  .button--caret .button__caret {
+    height: auto;
+  }
+
+  /*
+   * Loading modifier
+   */
+
+  .button--loading {
+    position: relative;
+    cursor: wait;
+  }
+
+  .button--loading .button__prefix,
+  .button--loading .button__label,
+  .button--loading .button__suffix,
+  .button--loading .button__caret {
+    visibility: hidden;
+  }
+
+  .button--loading sl-spinner {
+    --indicator-color: currentColor;
+    position: absolute;
+    font-size: 1em;
+    height: 1em;
+    width: 1em;
+    top: calc(50% - 0.5em);
+    left: calc(50% - 0.5em);
+  }
+
+  /*
+   * Badges
+   */
+
+  .button ::slotted(sl-badge) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    translate: 50% -50%;
+    pointer-events: none;
+  }
+
+  .button--rtl ::slotted(sl-badge) {
+    right: auto;
+    left: 0;
+    translate: -50% -50%;
+  }
+
+  /*
+   * Button spacing
+   */
+
+  .button--has-label.button--small .button__label {
+    padding: 0 var(--sl-spacing-small);
+  }
+
+  .button--has-label.button--medium .button__label {
+    padding: 0 var(--sl-spacing-medium);
+  }
+
+  .button--has-label.button--large .button__label {
+    padding: 0 var(--sl-spacing-large);
+  }
+
+  .button--has-prefix.button--small {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--small .button__label {
+    padding-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .button--has-prefix.button--medium {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--medium .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-prefix.button--large .button__label {
+    padding-inline-start: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--small,
+  .button--caret.button--small {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--small .button__label,
+  .button--caret.button--small .button__label {
+    padding-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .button--has-suffix.button--medium,
+  .button--caret.button--medium {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--medium .button__label,
+  .button--caret.button--medium .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large,
+  .button--caret.button--large {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .button--has-suffix.button--large .button__label,
+  .button--caret.button--large .button__label {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  /*
+   * Button groups support a variety of button types (e.g. buttons with tooltips, buttons as dropdown triggers, etc.).
+   * This means buttons aren't always direct descendants of the button group, thus we can't target them with the
+   * ::slotted selector. To work around this, the button group component does some magic to add these special classes to
+   * buttons and we style them here instead.
+   */
+
+  :host([data-sl-button-group__button--first]:not([data-sl-button-group__button--last])) .button {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  :host([data-sl-button-group__button--inner]) .button {
+    border-radius: 0;
+  }
+
+  :host([data-sl-button-group__button--last]:not([data-sl-button-group__button--first])) .button {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+
+  /* All except the first */
+  :host([data-sl-button-group__button]:not([data-sl-button-group__button--first])) {
+    margin-inline-start: calc(-1 * var(--sl-input-border-width));
+  }
+
+  /* Add a visual separator between solid buttons */
+  :host(
+      [data-sl-button-group__button]:not(
+          [data-sl-button-group__button--first],
+          [data-sl-button-group__button--radio],
+          [variant='default']
+        ):not(:hover)
+    )
+    .button:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    bottom: 0;
+    border-left: solid 1px rgb(128 128 128 / 33%);
+    mix-blend-mode: multiply;
+  }
+
+  /* Bump hovered, focused, and checked buttons up so their focus ring isn't clipped */
+  :host([data-sl-button-group__button--hover]) {
+    z-index: 1;
+  }
+
+  /* Focus and checked are always on top */
+  :host([data-sl-button-group__button--focus]),
+  :host([data-sl-button-group__button][checked]) {
+    z-index: 2;
+  }
+`,Ke=class{constructor(t,...r){this.slotNames=[],this.handleSlotChange=o=>{const i=o.target;(this.slotNames.includes("[default]")&&!i.name||i.name&&this.slotNames.includes(i.name))&&this.host.requestUpdate()},(this.host=t).addController(this),this.slotNames=r}hasDefaultSlot(){return[...this.host.childNodes].some(t=>{if(t.nodeType===t.TEXT_NODE&&t.textContent.trim()!=="")return!0;if(t.nodeType===t.ELEMENT_NODE){const r=t;if(r.tagName.toLowerCase()==="sl-visually-hidden")return!1;if(!r.hasAttribute("slot"))return!0}return!1})}hasNamedSlot(t){return this.host.querySelector(`:scope > [slot="${t}"]`)!==null}test(t){return t==="[default]"?this.hasDefaultSlot():this.hasNamedSlot(t)}hostConnected(){this.host.shadowRoot.addEventListener("slotchange",this.handleSlotChange)}hostDisconnected(){this.host.shadowRoot.removeEventListener("slotchange",this.handleSlotChange)}};function ju(t){if(!t)return"";const r=t.assignedNodes({flatten:!0});let o="";return[...r].forEach(i=>{i.nodeType===Node.TEXT_NODE&&(o+=i.textContent)}),o}var Ku=ct`
+  :host {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    box-sizing: content-box !important;
+  }
+
+  svg {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+`;function ht(t,r){const o=je({waitUntilFirstUpdate:!1},r);return(i,l)=>{const{update:c}=i,h=Array.isArray(t)?t:[t];i.update=function(m){h.forEach(k=>{const O=k;if(m.has(O)){const D=m.get(O),P=this[O];D!==P&&(!o.waitUntilFirstUpdate||this.hasUpdated)&&this[l](D,P)}}),c.call(this,m)}}}const{I:Hu}=Vl,Us=t=>t,Uu=(t,r)=>t?._$litType$!==void 0,$a=t=>t.strings===void 0,Ws=()=>document.createComment(""),Jr=(t,r,o)=>{const i=t._$AA.parentNode,l=r===void 0?t._$AB:r._$AA;if(o===void 0){const c=i.insertBefore(Ws(),l),h=i.insertBefore(Ws(),l);o=new Hu(c,h,t,t.options)}else{const c=o._$AB.nextSibling,h=o._$AM,m=h!==t;if(m){let k;o._$AQ?.(t),o._$AM=t,o._$AP!==void 0&&(k=t._$AU)!==h._$AU&&o._$AP(k)}if(c!==l||m){let k=o._$AA;for(;k!==c;){const O=Us(k).nextSibling;Us(i).insertBefore(k,l),k=O}}}return o},nr=(t,r,o=t)=>(t._$AI(r,o),t),Wu={},Aa=(t,r=Wu)=>t._$AH=r,Gu=t=>t._$AH,fi=t=>{t._$AR(),t._$AA.remove()};var tn=Symbol(),Gn=Symbol(),bi,mi=new Map,Ut=class extends gt{constructor(){super(...arguments),this.initialRender=!1,this.svg=null,this.label="",this.library="default"}async resolveIcon(t,r){var o;let i;if(r?.spriteSheet)return this.svg=X`<svg part="svg">
+        <use part="use" href="${t}"></use>
+      </svg>`,this.svg;try{if(i=await fetch(t,{mode:"cors"}),!i.ok)return i.status===410?tn:Gn}catch{return Gn}try{const l=document.createElement("div");l.innerHTML=await i.text();const c=l.firstElementChild;if(((o=c?.tagName)==null?void 0:o.toLowerCase())!=="svg")return tn;bi||(bi=new DOMParser);const m=bi.parseFromString(c.outerHTML,"text/html").body.querySelector("svg");return m?(m.part.add("svg"),document.adoptNode(m)):tn}catch{return tn}}connectedCallback(){super.connectedCallback(),uu(this)}firstUpdated(){this.initialRender=!0,this.setIcon()}disconnectedCallback(){super.disconnectedCallback(),cu(this)}getIconSource(){const t=Ks(this.library);return this.name&&t?{url:t.resolver(this.name),fromLibrary:!0}:{url:this.src,fromLibrary:!1}}handleLabelChange(){typeof this.label=="string"&&this.label.length>0?(this.setAttribute("role","img"),this.setAttribute("aria-label",this.label),this.removeAttribute("aria-hidden")):(this.removeAttribute("role"),this.removeAttribute("aria-label"),this.setAttribute("aria-hidden","true"))}async setIcon(){var t;const{url:r,fromLibrary:o}=this.getIconSource(),i=o?Ks(this.library):void 0;if(!r){this.svg=null;return}let l=mi.get(r);if(l||(l=this.resolveIcon(r,i),mi.set(r,l)),!this.initialRender)return;const c=await l;if(c===Gn&&mi.delete(r),r===this.getIconSource().url){if(Uu(c)){if(this.svg=c,i){await this.updateComplete;const h=this.shadowRoot.querySelector("[part='svg']");typeof i.mutator=="function"&&h&&i.mutator(h)}return}switch(c){case Gn:case tn:this.svg=null,this.emit("sl-error");break;default:this.svg=c.cloneNode(!0),(t=i?.mutator)==null||t.call(i,this.svg),this.emit("sl-load")}}}render(){return this.svg}};Ut.styles=[St,Ku];f([_t()],Ut.prototype,"svg",2);f([C({reflect:!0})],Ut.prototype,"name",2);f([C()],Ut.prototype,"src",2);f([C()],Ut.prototype,"label",2);f([C({reflect:!0})],Ut.prototype,"library",2);f([ht("label")],Ut.prototype,"handleLabelChange",1);f([ht(["name","src","library"])],Ut.prototype,"setIcon",1);const xe={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4},mo=t=>(...r)=>({_$litDirective$:t,values:r});let vo=class{constructor(r){}get _$AU(){return this._$AM._$AU}_$AT(r,o,i){this._$Ct=r,this._$AM=o,this._$Ci=i}_$AS(r,o){return this.update(r,o)}update(r,o){return this.render(...o)}};const kt=mo(class extends vo{constructor(t){if(super(t),t.type!==xe.ATTRIBUTE||t.name!=="class"||t.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(t){return" "+Object.keys(t).filter(r=>t[r]).join(" ")+" "}update(t,[r]){if(this.st===void 0){this.st=new Set,t.strings!==void 0&&(this.nt=new Set(t.strings.join(" ").split(/\s/).filter(i=>i!=="")));for(const i in r)r[i]&&!this.nt?.has(i)&&this.st.add(i);return this.render(r)}const o=t.element.classList;for(const i of this.st)i in r||(o.remove(i),this.st.delete(i));for(const i in r){const l=!!r[i];l===this.st.has(i)||this.nt?.has(i)||(l?(o.add(i),this.st.add(i)):(o.remove(i),this.st.delete(i)))}return ne}});const Sa=Symbol.for(""),Yu=t=>{if(t?.r===Sa)return t?._$litStatic$},oo=(t,...r)=>({_$litStatic$:r.reduce((o,i,l)=>o+(c=>{if(c._$litStatic$!==void 0)return c._$litStatic$;throw Error(`Value passed to 'literal' function must be a 'literal' result: ${c}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`)})(i)+t[l+1],t[0]),r:Sa}),Gs=new Map,Xu=t=>(r,...o)=>{const i=o.length;let l,c;const h=[],m=[];let k,O=0,D=!1;for(;O<i;){for(k=r[O];O<i&&(c=o[O],(l=Yu(c))!==void 0);)k+=l+r[++O],D=!0;O!==i&&m.push(c),h.push(k),O++}if(O===i&&h.push(r[i]),D){const P=h.join("$$lit$$");(r=Gs.get(P))===void 0&&(h.raw=h,Gs.set(P,r=h)),o=m}return t(r,...o)},an=Xu(X);const Y=t=>t??xt;var pt=class extends gt{constructor(){super(...arguments),this.formControlController=new bn(this,{assumeInteractionOn:["click"]}),this.hasSlotController=new Ke(this,"[default]","prefix","suffix"),this.localize=new ve(this),this.hasFocus=!1,this.invalid=!1,this.title="",this.variant="default",this.size="medium",this.caret=!1,this.disabled=!1,this.loading=!1,this.outline=!1,this.pill=!1,this.circle=!1,this.type="button",this.name="",this.value="",this.href="",this.rel="noreferrer noopener"}get validity(){return this.isButton()?this.button.validity:bo}get validationMessage(){return this.isButton()?this.button.validationMessage:""}firstUpdated(){this.isButton()&&this.formControlController.updateValidity()}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleClick(){this.type==="submit"&&this.formControlController.submit(this),this.type==="reset"&&this.formControlController.reset(this)}handleInvalid(t){this.formControlController.setValidity(!1),this.formControlController.emitInvalidEvent(t)}isButton(){return!this.href}isLink(){return!!this.href}handleDisabledChange(){this.isButton()&&this.formControlController.setValidity(this.disabled)}click(){this.button.click()}focus(t){this.button.focus(t)}blur(){this.button.blur()}checkValidity(){return this.isButton()?this.button.checkValidity():!0}getForm(){return this.formControlController.getForm()}reportValidity(){return this.isButton()?this.button.reportValidity():!0}setCustomValidity(t){this.isButton()&&(this.button.setCustomValidity(t),this.formControlController.updateValidity())}render(){const t=this.isLink(),r=t?oo`a`:oo`button`;return an`
+      <${r}
+        part="base"
+        class=${kt({button:!0,"button--default":this.variant==="default","button--primary":this.variant==="primary","button--success":this.variant==="success","button--neutral":this.variant==="neutral","button--warning":this.variant==="warning","button--danger":this.variant==="danger","button--text":this.variant==="text","button--small":this.size==="small","button--medium":this.size==="medium","button--large":this.size==="large","button--caret":this.caret,"button--circle":this.circle,"button--disabled":this.disabled,"button--focused":this.hasFocus,"button--loading":this.loading,"button--standard":!this.outline,"button--outline":this.outline,"button--pill":this.pill,"button--rtl":this.localize.dir()==="rtl","button--has-label":this.hasSlotController.test("[default]"),"button--has-prefix":this.hasSlotController.test("prefix"),"button--has-suffix":this.hasSlotController.test("suffix")})}
+        ?disabled=${Y(t?void 0:this.disabled)}
+        type=${Y(t?void 0:this.type)}
+        title=${this.title}
+        name=${Y(t?void 0:this.name)}
+        value=${Y(t?void 0:this.value)}
+        href=${Y(t&&!this.disabled?this.href:void 0)}
+        target=${Y(t?this.target:void 0)}
+        download=${Y(t?this.download:void 0)}
+        rel=${Y(t?this.rel:void 0)}
+        role=${Y(t?void 0:"button")}
+        aria-disabled=${this.disabled?"true":"false"}
+        tabindex=${this.disabled?"-1":"0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @invalid=${this.isButton()?this.handleInvalid:null}
+        @click=${this.handleClick}
+      >
+        <slot name="prefix" part="prefix" class="button__prefix"></slot>
+        <slot part="label" class="button__label"></slot>
+        <slot name="suffix" part="suffix" class="button__suffix"></slot>
+        ${this.caret?an` <sl-icon part="caret" class="button__caret" library="system" name="caret"></sl-icon> `:""}
+        ${this.loading?an`<sl-spinner part="spinner"></sl-spinner>`:""}
+      </${r}>
+    `}};pt.styles=[St,Ca];pt.dependencies={"sl-icon":Ut,"sl-spinner":Ii};f([st(".button")],pt.prototype,"button",2);f([_t()],pt.prototype,"hasFocus",2);f([_t()],pt.prototype,"invalid",2);f([C()],pt.prototype,"title",2);f([C({reflect:!0})],pt.prototype,"variant",2);f([C({reflect:!0})],pt.prototype,"size",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"caret",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"disabled",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"loading",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"outline",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"pill",2);f([C({type:Boolean,reflect:!0})],pt.prototype,"circle",2);f([C()],pt.prototype,"type",2);f([C()],pt.prototype,"name",2);f([C()],pt.prototype,"value",2);f([C()],pt.prototype,"href",2);f([C()],pt.prototype,"target",2);f([C()],pt.prototype,"rel",2);f([C()],pt.prototype,"download",2);f([C()],pt.prototype,"form",2);f([C({attribute:"formaction"})],pt.prototype,"formAction",2);f([C({attribute:"formenctype"})],pt.prototype,"formEnctype",2);f([C({attribute:"formmethod"})],pt.prototype,"formMethod",2);f([C({attribute:"formnovalidate",type:Boolean})],pt.prototype,"formNoValidate",2);f([C({attribute:"formtarget"})],pt.prototype,"formTarget",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],pt.prototype,"handleDisabledChange",1);pt.define("sl-button");var Qu=ct`
+  :host {
+    display: inline-block;
+  }
+
+  .button-group {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+`,Or=class extends gt{constructor(){super(...arguments),this.disableRole=!1,this.label=""}handleFocus(t){const r=en(t.target);r?.toggleAttribute("data-sl-button-group__button--focus",!0)}handleBlur(t){const r=en(t.target);r?.toggleAttribute("data-sl-button-group__button--focus",!1)}handleMouseOver(t){const r=en(t.target);r?.toggleAttribute("data-sl-button-group__button--hover",!0)}handleMouseOut(t){const r=en(t.target);r?.toggleAttribute("data-sl-button-group__button--hover",!1)}handleSlotChange(){const t=[...this.defaultSlot.assignedElements({flatten:!0})];t.forEach(r=>{const o=t.indexOf(r),i=en(r);i&&(i.toggleAttribute("data-sl-button-group__button",!0),i.toggleAttribute("data-sl-button-group__button--first",o===0),i.toggleAttribute("data-sl-button-group__button--inner",o>0&&o<t.length-1),i.toggleAttribute("data-sl-button-group__button--last",o===t.length-1),i.toggleAttribute("data-sl-button-group__button--radio",i.tagName.toLowerCase()==="sl-radio-button"))})}render(){return X`
+      <div
+        part="base"
+        class="button-group"
+        role="${this.disableRole?"presentation":"group"}"
+        aria-label=${this.label}
+        @focusout=${this.handleBlur}
+        @focusin=${this.handleFocus}
+        @mouseover=${this.handleMouseOver}
+        @mouseout=${this.handleMouseOut}
+      >
+        <slot @slotchange=${this.handleSlotChange}></slot>
+      </div>
+    `}};Or.styles=[St,Qu];f([st("slot")],Or.prototype,"defaultSlot",2);f([_t()],Or.prototype,"disableRole",2);f([C()],Or.prototype,"label",2);function en(t){var r;const o="sl-button, sl-radio-button";return(r=t.closest(o))!=null?r:t.querySelector(o)}Or.define("sl-button-group");var Zu=ct`
+  :host {
+    display: inline-block;
+  }
+
+  .checkbox {
+    position: relative;
+    display: inline-flex;
+    align-items: flex-start;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    color: var(--sl-input-label-color);
+    vertical-align: middle;
+    cursor: pointer;
+  }
+
+  .checkbox--small {
+    --toggle-size: var(--sl-toggle-size-small);
+    font-size: var(--sl-input-font-size-small);
+  }
+
+  .checkbox--medium {
+    --toggle-size: var(--sl-toggle-size-medium);
+    font-size: var(--sl-input-font-size-medium);
+  }
+
+  .checkbox--large {
+    --toggle-size: var(--sl-toggle-size-large);
+    font-size: var(--sl-input-font-size-large);
+  }
+
+  .checkbox__control {
+    flex: 0 0 auto;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--toggle-size);
+    height: var(--toggle-size);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+    border-radius: 2px;
+    background-color: var(--sl-input-background-color);
+    color: var(--sl-color-neutral-0);
+    transition:
+      var(--sl-transition-fast) border-color,
+      var(--sl-transition-fast) background-color,
+      var(--sl-transition-fast) color,
+      var(--sl-transition-fast) box-shadow;
+  }
+
+  .checkbox__input {
+    position: absolute;
+    opacity: 0;
+    padding: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .checkbox__checked-icon,
+  .checkbox__indeterminate-icon {
+    display: inline-flex;
+    width: var(--toggle-size);
+    height: var(--toggle-size);
+  }
+
+  /* Hover */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-input-border-color-hover);
+    background-color: var(--sl-input-background-color-hover);
+  }
+
+  /* Focus */
+  .checkbox:not(.checkbox--checked):not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Checked/indeterminate */
+  .checkbox--checked .checkbox__control,
+  .checkbox--indeterminate .checkbox__control {
+    border-color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-primary-600);
+  }
+
+  /* Checked/indeterminate + hover */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__control:hover,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__control:hover {
+    border-color: var(--sl-color-primary-500);
+    background-color: var(--sl-color-primary-500);
+  }
+
+  /* Checked/indeterminate + focus */
+  .checkbox.checkbox--checked:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control,
+  .checkbox.checkbox--indeterminate:not(.checkbox--disabled) .checkbox__input:focus-visible ~ .checkbox__control {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  /* Disabled */
+  .checkbox--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .checkbox__label {
+    display: inline-block;
+    color: var(--sl-input-label-color);
+    line-height: var(--toggle-size);
+    margin-inline-start: 0.5em;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  :host([required]) .checkbox__label::after {
+    content: var(--sl-input-required-content);
+    color: var(--sl-input-required-content-color);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+`,Li=(t="value")=>(r,o)=>{const i=r.constructor,l=i.prototype.attributeChangedCallback;i.prototype.attributeChangedCallback=function(c,h,m){var k;const O=i.getPropertyOptions(t),D=typeof O.attribute=="string"?O.attribute:t;if(c===D){const P=O.converter||xr,R=(typeof P=="function"?P:(k=P?.fromAttribute)!=null?k:xr.fromAttribute)(m,O.type);this[t]!==R&&(this[o]=R)}l.call(this,c,h,m)}},go=ct`
+  .form-control .form-control__label {
+    display: none;
+  }
+
+  .form-control .form-control__help-text {
+    display: none;
+  }
+
+  /* Label */
+  .form-control--has-label .form-control__label {
+    display: inline-block;
+    color: var(--sl-input-label-color);
+    margin-bottom: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-label.form-control--small .form-control__label {
+    font-size: var(--sl-input-label-font-size-small);
+  }
+
+  .form-control--has-label.form-control--medium .form-control__label {
+    font-size: var(--sl-input-label-font-size-medium);
+  }
+
+  .form-control--has-label.form-control--large .form-control__label {
+    font-size: var(--sl-input-label-font-size-large);
+  }
+
+  :host([required]) .form-control--has-label .form-control__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+    color: var(--sl-input-required-content-color);
+  }
+
+  /* Help text */
+  .form-control--has-help-text .form-control__help-text {
+    display: block;
+    color: var(--sl-input-help-text-color);
+    margin-top: var(--sl-spacing-3x-small);
+  }
+
+  .form-control--has-help-text.form-control--small .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-small);
+  }
+
+  .form-control--has-help-text.form-control--medium .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-medium);
+  }
+
+  .form-control--has-help-text.form-control--large .form-control__help-text {
+    font-size: var(--sl-input-help-text-font-size-large);
+  }
+
+  .form-control--has-help-text.form-control--radio-group .form-control__help-text {
+    margin-top: var(--sl-spacing-2x-small);
+  }
+`;const io=mo(class extends vo{constructor(t){if(super(t),t.type!==xe.PROPERTY&&t.type!==xe.ATTRIBUTE&&t.type!==xe.BOOLEAN_ATTRIBUTE)throw Error("The `live` directive is not allowed on child or event bindings");if(!$a(t))throw Error("`live` bindings can only contain a single expression")}render(t){return t}update(t,[r]){if(r===ne||r===xt)return r;const o=t.element,i=t.name;if(t.type===xe.PROPERTY){if(r===o[i])return ne}else if(t.type===xe.BOOLEAN_ATTRIBUTE){if(!!r===o.hasAttribute(i))return ne}else if(t.type===xe.ATTRIBUTE&&o.getAttribute(i)===r+"")return ne;return Aa(t),r}});var Pt=class extends gt{constructor(){super(...arguments),this.formControlController=new bn(this,{value:t=>t.checked?t.value||"on":void 0,defaultValue:t=>t.defaultChecked,setValue:(t,r)=>t.checked=r}),this.hasSlotController=new Ke(this,"help-text"),this.hasFocus=!1,this.title="",this.name="",this.size="medium",this.disabled=!1,this.checked=!1,this.indeterminate=!1,this.defaultChecked=!1,this.form="",this.required=!1,this.helpText=""}get validity(){return this.input.validity}get validationMessage(){return this.input.validationMessage}firstUpdated(){this.formControlController.updateValidity()}handleClick(){this.checked=!this.checked,this.indeterminate=!1,this.emit("sl-change")}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleInput(){this.emit("sl-input")}handleInvalid(t){this.formControlController.setValidity(!1),this.formControlController.emitInvalidEvent(t)}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleDisabledChange(){this.formControlController.setValidity(this.disabled)}handleStateChange(){this.input.checked=this.checked,this.input.indeterminate=this.indeterminate,this.formControlController.updateValidity()}click(){this.input.click()}focus(t){this.input.focus(t)}blur(){this.input.blur()}checkValidity(){return this.input.checkValidity()}getForm(){return this.formControlController.getForm()}reportValidity(){return this.input.reportValidity()}setCustomValidity(t){this.input.setCustomValidity(t),this.formControlController.updateValidity()}render(){const t=this.hasSlotController.test("help-text"),r=this.helpText?!0:!!t;return X`
+      <div
+        class=${kt({"form-control":!0,"form-control--small":this.size==="small","form-control--medium":this.size==="medium","form-control--large":this.size==="large","form-control--has-help-text":r})}
+      >
+        <label
+          part="base"
+          class=${kt({checkbox:!0,"checkbox--checked":this.checked,"checkbox--disabled":this.disabled,"checkbox--focused":this.hasFocus,"checkbox--indeterminate":this.indeterminate,"checkbox--small":this.size==="small","checkbox--medium":this.size==="medium","checkbox--large":this.size==="large"})}
+        >
+          <input
+            class="checkbox__input"
+            type="checkbox"
+            title=${this.title}
+            name=${this.name}
+            value=${Y(this.value)}
+            .indeterminate=${io(this.indeterminate)}
+            .checked=${io(this.checked)}
+            .disabled=${this.disabled}
+            .required=${this.required}
+            aria-checked=${this.checked?"true":"false"}
+            aria-describedby="help-text"
+            @click=${this.handleClick}
+            @input=${this.handleInput}
+            @invalid=${this.handleInvalid}
+            @blur=${this.handleBlur}
+            @focus=${this.handleFocus}
+          />
+
+          <span
+            part="control${this.checked?" control--checked":""}${this.indeterminate?" control--indeterminate":""}"
+            class="checkbox__control"
+          >
+            ${this.checked?X`
+                  <sl-icon part="checked-icon" class="checkbox__checked-icon" library="system" name="check"></sl-icon>
+                `:""}
+            ${!this.checked&&this.indeterminate?X`
+                  <sl-icon
+                    part="indeterminate-icon"
+                    class="checkbox__indeterminate-icon"
+                    library="system"
+                    name="indeterminate"
+                  ></sl-icon>
+                `:""}
+          </span>
+
+          <div part="label" class="checkbox__label">
+            <slot></slot>
+          </div>
+        </label>
+
+        <div
+          aria-hidden=${r?"false":"true"}
+          class="form-control__help-text"
+          id="help-text"
+          part="form-control-help-text"
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `}};Pt.styles=[St,go,Zu];Pt.dependencies={"sl-icon":Ut};f([st('input[type="checkbox"]')],Pt.prototype,"input",2);f([_t()],Pt.prototype,"hasFocus",2);f([C()],Pt.prototype,"title",2);f([C()],Pt.prototype,"name",2);f([C()],Pt.prototype,"value",2);f([C({reflect:!0})],Pt.prototype,"size",2);f([C({type:Boolean,reflect:!0})],Pt.prototype,"disabled",2);f([C({type:Boolean,reflect:!0})],Pt.prototype,"checked",2);f([C({type:Boolean,reflect:!0})],Pt.prototype,"indeterminate",2);f([Li("checked")],Pt.prototype,"defaultChecked",2);f([C({reflect:!0})],Pt.prototype,"form",2);f([C({type:Boolean,reflect:!0})],Pt.prototype,"required",2);f([C({attribute:"help-text"})],Pt.prototype,"helpText",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],Pt.prototype,"handleDisabledChange",1);f([ht(["checked","indeterminate"],{waitUntilFirstUpdate:!0})],Pt.prototype,"handleStateChange",1);Pt.define("sl-checkbox");function*Fi(t=document.activeElement){t!=null&&(yield t,"shadowRoot"in t&&t.shadowRoot&&t.shadowRoot.mode!=="closed"&&(yield*ou(Fi(t.shadowRoot.activeElement))))}function Ea(){return[...Fi()].pop()}var Ys=new WeakMap;function Ta(t){let r=Ys.get(t);return r||(r=window.getComputedStyle(t,null),Ys.set(t,r)),r}function Ju(t){if(typeof t.checkVisibility=="function")return t.checkVisibility({checkOpacity:!1,checkVisibilityCSS:!0});const r=Ta(t);return r.visibility!=="hidden"&&r.display!=="none"}function tc(t){const r=Ta(t),{overflowY:o,overflowX:i}=r;return o==="scroll"||i==="scroll"?!0:o!=="auto"||i!=="auto"?!1:t.scrollHeight>t.clientHeight&&o==="auto"||t.scrollWidth>t.clientWidth&&i==="auto"}function ec(t){const r=t.tagName.toLowerCase(),o=Number(t.getAttribute("tabindex"));if(t.hasAttribute("tabindex")&&(isNaN(o)||o<=-1)||t.hasAttribute("disabled")||t.closest("[inert]"))return!1;if(r==="input"&&t.getAttribute("type")==="radio"){const c=t.getRootNode(),h=`input[type='radio'][name="${t.getAttribute("name")}"]`,m=c.querySelector(`${h}:checked`);return m?m===t:c.querySelector(h)===t}return Ju(t)?(r==="audio"||r==="video")&&t.hasAttribute("controls")||t.hasAttribute("tabindex")||t.hasAttribute("contenteditable")&&t.getAttribute("contenteditable")!=="false"||["button","input","select","textarea","a","audio","video","summary","iframe"].includes(r)?!0:tc(t):!1}function rc(t){var r,o;const i=ki(t),l=(r=i[0])!=null?r:null,c=(o=i[i.length-1])!=null?o:null;return{start:l,end:c}}function nc(t,r){var o;return((o=t.getRootNode({composed:!0}))==null?void 0:o.host)!==r}function ki(t){const r=new WeakMap,o=[];function i(l){if(l instanceof Element){if(l.hasAttribute("inert")||l.closest("[inert]")||r.has(l))return;r.set(l,!0),!o.includes(l)&&ec(l)&&o.push(l),l instanceof HTMLSlotElement&&nc(l,t)&&l.assignedElements({flatten:!0}).forEach(c=>{i(c)}),l.shadowRoot!==null&&l.shadowRoot.mode==="open"&&i(l.shadowRoot)}for(const c of l.children)i(c)}return i(t),o.sort((l,c)=>{const h=Number(l.getAttribute("tabindex"))||0;return(Number(c.getAttribute("tabindex"))||0)-h})}var rn=[],oc=class{constructor(t){this.tabDirection="forward",this.handleFocusIn=()=>{this.isActive()&&this.checkFocus()},this.handleKeyDown=r=>{var o;if(r.key!=="Tab"||this.isExternalActivated||!this.isActive())return;const i=Ea();if(this.previousFocus=i,this.previousFocus&&this.possiblyHasTabbableChildren(this.previousFocus))return;r.shiftKey?this.tabDirection="backward":this.tabDirection="forward";const l=ki(this.element);let c=l.findIndex(m=>m===i);this.previousFocus=this.currentFocus;const h=this.tabDirection==="forward"?1:-1;for(;;){c+h>=l.length?c=0:c+h<0?c=l.length-1:c+=h,this.previousFocus=this.currentFocus;const m=l[c];if(this.tabDirection==="backward"&&this.previousFocus&&this.possiblyHasTabbableChildren(this.previousFocus)||m&&this.possiblyHasTabbableChildren(m))return;r.preventDefault(),this.currentFocus=m,(o=this.currentFocus)==null||o.focus({preventScroll:!1});const k=[...Fi()];if(k.includes(this.currentFocus)||!k.includes(this.previousFocus))break}setTimeout(()=>this.checkFocus())},this.handleKeyUp=()=>{this.tabDirection="forward"},this.element=t,this.elementsWithTabbableControls=["iframe"]}activate(){rn.push(this.element),document.addEventListener("focusin",this.handleFocusIn),document.addEventListener("keydown",this.handleKeyDown),document.addEventListener("keyup",this.handleKeyUp)}deactivate(){rn=rn.filter(t=>t!==this.element),this.currentFocus=null,document.removeEventListener("focusin",this.handleFocusIn),document.removeEventListener("keydown",this.handleKeyDown),document.removeEventListener("keyup",this.handleKeyUp)}isActive(){return rn[rn.length-1]===this.element}activateExternal(){this.isExternalActivated=!0}deactivateExternal(){this.isExternalActivated=!1}checkFocus(){if(this.isActive()&&!this.isExternalActivated){const t=ki(this.element);if(!this.element.matches(":focus-within")){const r=t[0],o=t[t.length-1],i=this.tabDirection==="forward"?r:o;typeof i?.focus=="function"&&(this.currentFocus=i,i.focus({preventScroll:!1}))}}}possiblyHasTabbableChildren(t){return this.elementsWithTabbableControls.includes(t.tagName.toLowerCase())||t.hasAttribute("controls")}};function ic(t,r){return{top:Math.round(t.getBoundingClientRect().top-r.getBoundingClientRect().top),left:Math.round(t.getBoundingClientRect().left-r.getBoundingClientRect().left)}}var Ci=new Set;function sc(){const t=document.documentElement.clientWidth;return Math.abs(window.innerWidth-t)}function ac(){const t=Number(getComputedStyle(document.body).paddingRight.replace(/px/,""));return isNaN(t)||!t?0:t}function Xs(t){if(Ci.add(t),!document.documentElement.classList.contains("sl-scroll-lock")){const r=sc()+ac();let o=getComputedStyle(document.documentElement).scrollbarGutter;(!o||o==="auto")&&(o="stable"),r<2&&(o=""),document.documentElement.style.setProperty("--sl-scroll-lock-gutter",o),document.documentElement.classList.add("sl-scroll-lock"),document.documentElement.style.setProperty("--sl-scroll-lock-size",`${r}px`)}}function Qs(t){Ci.delete(t),Ci.size===0&&(document.documentElement.classList.remove("sl-scroll-lock"),document.documentElement.style.removeProperty("--sl-scroll-lock-size"))}function Zs(t,r,o="vertical",i="smooth"){const l=ic(t,r),c=l.top+r.scrollTop,h=l.left+r.scrollLeft,m=r.scrollLeft,k=r.scrollLeft+r.offsetWidth,O=r.scrollTop,D=r.scrollTop+r.offsetHeight;(o==="horizontal"||o==="both")&&(h<m?r.scrollTo({left:h,behavior:i}):h+t.clientWidth>k&&r.scrollTo({left:h-r.offsetWidth+t.clientWidth,behavior:i})),(o==="vertical"||o==="both")&&(c<O?r.scrollTo({top:c,behavior:i}):c+t.clientHeight>D&&r.scrollTo({top:c-r.offsetHeight+t.clientHeight,behavior:i}))}var lc=ct`
+  :host {
+    --width: 31rem;
+    --header-spacing: var(--sl-spacing-large);
+    --body-spacing: var(--sl-spacing-large);
+    --footer-spacing: var(--sl-spacing-large);
+
+    display: contents;
+  }
+
+  .dialog {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: var(--sl-z-index-dialog);
+  }
+
+  .dialog__panel {
+    display: flex;
+    flex-direction: column;
+    z-index: 2;
+    width: var(--width);
+    max-width: calc(100% - var(--sl-spacing-2x-large));
+    max-height: calc(100% - var(--sl-spacing-2x-large));
+    background-color: var(--sl-panel-background-color);
+    border-radius: var(--sl-border-radius-medium);
+    box-shadow: var(--sl-shadow-x-large);
+  }
+
+  .dialog__panel:focus {
+    outline: none;
+  }
+
+  /* Ensure there's enough vertical padding for phones that don't update vh when chrome appears (e.g. iPhone) */
+  @media screen and (max-width: 420px) {
+    .dialog__panel {
+      max-height: 80vh;
+    }
+  }
+
+  .dialog--open .dialog__panel {
+    display: flex;
+    opacity: 1;
+  }
+
+  .dialog__header {
+    flex: 0 0 auto;
+    display: flex;
+  }
+
+  .dialog__title {
+    flex: 1 1 auto;
+    font: inherit;
+    font-size: var(--sl-font-size-large);
+    line-height: var(--sl-line-height-dense);
+    padding: var(--header-spacing);
+    margin: 0;
+  }
+
+  .dialog__header-actions {
+    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: end;
+    gap: var(--sl-spacing-2x-small);
+    padding: 0 var(--header-spacing);
+  }
+
+  .dialog__header-actions sl-icon-button,
+  .dialog__header-actions ::slotted(sl-icon-button) {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    font-size: var(--sl-font-size-medium);
+  }
+
+  .dialog__body {
+    flex: 1 1 auto;
+    display: block;
+    padding: var(--body-spacing);
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .dialog__footer {
+    flex: 0 0 auto;
+    text-align: right;
+    padding: var(--footer-spacing);
+  }
+
+  .dialog__footer ::slotted(sl-button:not(:first-of-type)) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  .dialog:not(.dialog--has-footer) .dialog__footer {
+    display: none;
+  }
+
+  .dialog__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: var(--sl-overlay-background-color);
+  }
+
+  @media (forced-colors: active) {
+    .dialog__panel {
+      border: solid 1px var(--sl-color-neutral-0);
+    }
+  }
+`,uc=t=>{var r;const{activeElement:o}=document;o&&t.contains(o)&&((r=document.activeElement)==null||r.blur())},cc=ct`
+  :host {
+    display: inline-block;
+    color: var(--sl-color-neutral-600);
+  }
+
+  .icon-button {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    background: none;
+    border: none;
+    border-radius: var(--sl-border-radius-medium);
+    font-size: inherit;
+    color: inherit;
+    padding: var(--sl-spacing-x-small);
+    cursor: pointer;
+    transition: var(--sl-transition-x-fast) color;
+    -webkit-appearance: none;
+  }
+
+  .icon-button:hover:not(.icon-button--disabled),
+  .icon-button:focus-visible:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .icon-button:active:not(.icon-button--disabled) {
+    color: var(--sl-color-primary-700);
+  }
+
+  .icon-button:focus {
+    outline: none;
+  }
+
+  .icon-button--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .icon-button:focus-visible {
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .icon-button__icon {
+    pointer-events: none;
+  }
+`,Nt=class extends gt{constructor(){super(...arguments),this.hasFocus=!1,this.label="",this.disabled=!1}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleClick(t){this.disabled&&(t.preventDefault(),t.stopPropagation())}click(){this.button.click()}focus(t){this.button.focus(t)}blur(){this.button.blur()}render(){const t=!!this.href,r=t?oo`a`:oo`button`;return an`
+      <${r}
+        part="base"
+        class=${kt({"icon-button":!0,"icon-button--disabled":!t&&this.disabled,"icon-button--focused":this.hasFocus})}
+        ?disabled=${Y(t?void 0:this.disabled)}
+        type=${Y(t?void 0:"button")}
+        href=${Y(t?this.href:void 0)}
+        target=${Y(t?this.target:void 0)}
+        download=${Y(t?this.download:void 0)}
+        rel=${Y(t&&this.target?"noreferrer noopener":void 0)}
+        role=${Y(t?void 0:"button")}
+        aria-disabled=${this.disabled?"true":"false"}
+        aria-label="${this.label}"
+        tabindex=${this.disabled?"-1":"0"}
+        @blur=${this.handleBlur}
+        @focus=${this.handleFocus}
+        @click=${this.handleClick}
+      >
+        <sl-icon
+          class="icon-button__icon"
+          name=${Y(this.name)}
+          library=${Y(this.library)}
+          src=${Y(this.src)}
+          aria-hidden="true"
+        ></sl-icon>
+      </${r}>
+    `}};Nt.styles=[St,cc];Nt.dependencies={"sl-icon":Ut};f([st(".icon-button")],Nt.prototype,"button",2);f([_t()],Nt.prototype,"hasFocus",2);f([C()],Nt.prototype,"name",2);f([C()],Nt.prototype,"library",2);f([C()],Nt.prototype,"src",2);f([C()],Nt.prototype,"href",2);f([C()],Nt.prototype,"target",2);f([C()],Nt.prototype,"download",2);f([C()],Nt.prototype,"label",2);f([C({type:Boolean,reflect:!0})],Nt.prototype,"disabled",2);var Oa=new Map,dc=new WeakMap;function hc(t){return t??{keyframes:[],options:{duration:0}}}function Js(t,r){return r.toLowerCase()==="rtl"?{keyframes:t.rtlKeyframes||t.keyframes,options:t.options}:t}function Se(t,r){Oa.set(t,hc(r))}function ke(t,r,o){const i=dc.get(t);if(i?.[r])return Js(i[r],o.dir);const l=Oa.get(r);return l?Js(l,o.dir):{keyframes:[],options:{duration:0}}}function Cr(t,r){return new Promise(o=>{function i(l){l.target===t&&(t.removeEventListener(r,i),o())}t.addEventListener(r,i)})}function Ce(t,r,o){return new Promise(i=>{if(o?.duration===1/0)throw new Error("Promise-based animations must be finite.");const l=t.animate(r,fo(je({},o),{duration:pc()?0:o.duration}));l.addEventListener("cancel",i,{once:!0}),l.addEventListener("finish",i,{once:!0})})}function ta(t){return t=t.toString().toLowerCase(),t.indexOf("ms")>-1?parseFloat(t):t.indexOf("s")>-1?parseFloat(t)*1e3:parseFloat(t)}function pc(){return window.matchMedia("(prefers-reduced-motion: reduce)").matches}function Be(t){return Promise.all(t.getAnimations().map(r=>new Promise(o=>{r.cancel(),requestAnimationFrame(o)})))}var ge=class extends gt{constructor(){super(...arguments),this.hasSlotController=new Ke(this,"footer"),this.localize=new ve(this),this.modal=new oc(this),this.open=!1,this.label="",this.noHeader=!1,this.handleDocumentKeyDown=t=>{t.key==="Escape"&&this.modal.isActive()&&this.open&&(t.stopPropagation(),this.requestClose("keyboard"))}}firstUpdated(){this.dialog.hidden=!this.open,this.open&&(this.addOpenListeners(),this.modal.activate(),Xs(this))}disconnectedCallback(){super.disconnectedCallback(),this.modal.deactivate(),Qs(this),this.removeOpenListeners()}requestClose(t){if(this.emit("sl-request-close",{cancelable:!0,detail:{source:t}}).defaultPrevented){const o=ke(this,"dialog.denyClose",{dir:this.localize.dir()});Ce(this.panel,o.keyframes,o.options);return}this.hide()}addOpenListeners(){var t;"CloseWatcher"in window?((t=this.closeWatcher)==null||t.destroy(),this.closeWatcher=new CloseWatcher,this.closeWatcher.onclose=()=>this.requestClose("keyboard")):document.addEventListener("keydown",this.handleDocumentKeyDown)}removeOpenListeners(){var t;(t=this.closeWatcher)==null||t.destroy(),document.removeEventListener("keydown",this.handleDocumentKeyDown)}async handleOpenChange(){if(this.open){this.emit("sl-show"),this.addOpenListeners(),this.originalTrigger=document.activeElement,this.modal.activate(),Xs(this);const t=this.querySelector("[autofocus]");t&&t.removeAttribute("autofocus"),await Promise.all([Be(this.dialog),Be(this.overlay)]),this.dialog.hidden=!1,requestAnimationFrame(()=>{this.emit("sl-initial-focus",{cancelable:!0}).defaultPrevented||(t?t.focus({preventScroll:!0}):this.panel.focus({preventScroll:!0})),t&&t.setAttribute("autofocus","")});const r=ke(this,"dialog.show",{dir:this.localize.dir()}),o=ke(this,"dialog.overlay.show",{dir:this.localize.dir()});await Promise.all([Ce(this.panel,r.keyframes,r.options),Ce(this.overlay,o.keyframes,o.options)]),this.emit("sl-after-show")}else{uc(this),this.emit("sl-hide"),this.removeOpenListeners(),this.modal.deactivate(),await Promise.all([Be(this.dialog),Be(this.overlay)]);const t=ke(this,"dialog.hide",{dir:this.localize.dir()}),r=ke(this,"dialog.overlay.hide",{dir:this.localize.dir()});await Promise.all([Ce(this.overlay,r.keyframes,r.options).then(()=>{this.overlay.hidden=!0}),Ce(this.panel,t.keyframes,t.options).then(()=>{this.panel.hidden=!0})]),this.dialog.hidden=!0,this.overlay.hidden=!1,this.panel.hidden=!1,Qs(this);const o=this.originalTrigger;typeof o?.focus=="function"&&setTimeout(()=>o.focus()),this.emit("sl-after-hide")}}async show(){if(!this.open)return this.open=!0,Cr(this,"sl-after-show")}async hide(){if(this.open)return this.open=!1,Cr(this,"sl-after-hide")}render(){return X`
+      <div
+        part="base"
+        class=${kt({dialog:!0,"dialog--open":this.open,"dialog--has-footer":this.hasSlotController.test("footer")})}
+      >
+        <div part="overlay" class="dialog__overlay" @click=${()=>this.requestClose("overlay")} tabindex="-1"></div>
+
+        <div
+          part="panel"
+          class="dialog__panel"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden=${this.open?"false":"true"}
+          aria-label=${Y(this.noHeader?this.label:void 0)}
+          aria-labelledby=${Y(this.noHeader?void 0:"title")}
+          tabindex="-1"
+        >
+          ${this.noHeader?"":X`
+                <header part="header" class="dialog__header">
+                  <h2 part="title" class="dialog__title" id="title">
+                    <slot name="label"> ${this.label.length>0?this.label:"\uFEFF"} </slot>
+                  </h2>
+                  <div part="header-actions" class="dialog__header-actions">
+                    <slot name="header-actions"></slot>
+                    <sl-icon-button
+                      part="close-button"
+                      exportparts="base:close-button__base"
+                      class="dialog__close"
+                      name="x-lg"
+                      label=${this.localize.term("close")}
+                      library="system"
+                      @click="${()=>this.requestClose("close-button")}"
+                    ></sl-icon-button>
+                  </div>
+                </header>
+              `}
+          ${""}
+          <div part="body" class="dialog__body" tabindex="-1"><slot></slot></div>
+
+          <footer part="footer" class="dialog__footer">
+            <slot name="footer"></slot>
+          </footer>
+        </div>
+      </div>
+    `}};ge.styles=[St,lc];ge.dependencies={"sl-icon-button":Nt};f([st(".dialog")],ge.prototype,"dialog",2);f([st(".dialog__panel")],ge.prototype,"panel",2);f([st(".dialog__overlay")],ge.prototype,"overlay",2);f([C({type:Boolean,reflect:!0})],ge.prototype,"open",2);f([C({reflect:!0})],ge.prototype,"label",2);f([C({attribute:"no-header",type:Boolean,reflect:!0})],ge.prototype,"noHeader",2);f([ht("open",{waitUntilFirstUpdate:!0})],ge.prototype,"handleOpenChange",1);Se("dialog.show",{keyframes:[{opacity:0,scale:.8},{opacity:1,scale:1}],options:{duration:250,easing:"ease"}});Se("dialog.hide",{keyframes:[{opacity:1,scale:1},{opacity:0,scale:.8}],options:{duration:250,easing:"ease"}});Se("dialog.denyClose",{keyframes:[{scale:1},{scale:1.02},{scale:1}],options:{duration:250}});Se("dialog.overlay.show",{keyframes:[{opacity:0},{opacity:1}],options:{duration:250}});Se("dialog.overlay.hide",{keyframes:[{opacity:1},{opacity:0}],options:{duration:250}});ge.define("sl-dialog");var fc=ct`
+  :host {
+    --color: var(--sl-panel-border-color);
+    --width: var(--sl-panel-border-width);
+    --spacing: var(--sl-spacing-medium);
+  }
+
+  :host(:not([vertical])) {
+    display: block;
+    border-top: solid var(--width) var(--color);
+    margin: var(--spacing) 0;
+  }
+
+  :host([vertical]) {
+    display: inline-block;
+    height: 100%;
+    border-left: solid var(--width) var(--color);
+    margin: 0 var(--spacing);
+  }
+`,yo=class extends gt{constructor(){super(...arguments),this.vertical=!1}connectedCallback(){super.connectedCallback(),this.setAttribute("role","separator")}handleVerticalChange(){this.setAttribute("aria-orientation",this.vertical?"vertical":"horizontal")}};yo.styles=[St,fc];f([C({type:Boolean,reflect:!0})],yo.prototype,"vertical",2);f([ht("vertical")],yo.prototype,"handleVerticalChange",1);yo.define("sl-divider");Ut.define("sl-icon");var bc=ct`
+  :host {
+    display: block;
+  }
+
+  .input {
+    flex: 1 1 auto;
+    display: inline-flex;
+    align-items: stretch;
+    justify-content: start;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    overflow: hidden;
+    cursor: text;
+    transition:
+      var(--sl-transition-fast) color,
+      var(--sl-transition-fast) border,
+      var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+  }
+
+  /* Standard inputs */
+  .input--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .input--standard:hover:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .input--standard.input--focused:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .input--standard.input--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input--standard.input--disabled .input__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .input--standard.input--disabled .input__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled inputs */
+  .input--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .input--filled:hover:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .input--filled.input--focused:not(.input--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .input--filled.input--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .input__control {
+    flex: 1 1 auto;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    min-width: 0;
+    height: 100%;
+    color: var(--sl-input-color);
+    border: none;
+    background: inherit;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .input__control::-webkit-search-decoration,
+  .input__control::-webkit-search-cancel-button,
+  .input__control::-webkit-search-results-button,
+  .input__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .input__control:-webkit-autofill,
+  .input__control:-webkit-autofill:hover,
+  .input__control:-webkit-autofill:focus,
+  .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-background-color-hover) inset !important;
+    -webkit-text-fill-color: var(--sl-color-primary-500);
+    caret-color: var(--sl-input-color);
+  }
+
+  .input--filled .input__control:-webkit-autofill,
+  .input--filled .input__control:-webkit-autofill:hover,
+  .input--filled .input__control:-webkit-autofill:focus,
+  .input--filled .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-filled-background-color) inset !important;
+  }
+
+  .input__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  .input:hover:not(.input--disabled) .input__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .input__control:focus {
+    outline: none;
+  }
+
+  .input__prefix,
+  .input__suffix {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    cursor: default;
+  }
+
+  .input__prefix ::slotted(sl-icon),
+  .input__suffix ::slotted(sl-icon) {
+    color: var(--sl-input-icon-color);
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .input--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+    height: var(--sl-input-height-small);
+  }
+
+  .input--small .input__control {
+    height: calc(var(--sl-input-height-small) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__clear,
+  .input--small .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-small) * 2);
+  }
+
+  .input--small .input__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-small);
+  }
+
+  .input--small .input__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-small);
+  }
+
+  .input--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+    height: var(--sl-input-height-medium);
+  }
+
+  .input--medium .input__control {
+    height: calc(var(--sl-input-height-medium) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__clear,
+  .input--medium .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-medium) * 2);
+  }
+
+  .input--medium .input__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-medium);
+  }
+
+  .input--medium .input__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-medium);
+  }
+
+  .input--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+    height: var(--sl-input-height-large);
+  }
+
+  .input--large .input__control {
+    height: calc(var(--sl-input-height-large) - var(--sl-input-border-width) * 2);
+    padding: 0 var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__clear,
+  .input--large .input__password-toggle {
+    width: calc(1em + var(--sl-input-spacing-large) * 2);
+  }
+
+  .input--large .input__prefix ::slotted(*) {
+    margin-inline-start: var(--sl-input-spacing-large);
+  }
+
+  .input--large .input__suffix ::slotted(*) {
+    margin-inline-end: var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Pill modifier
+   */
+
+  .input--pill.input--small {
+    border-radius: var(--sl-input-height-small);
+  }
+
+  .input--pill.input--medium {
+    border-radius: var(--sl-input-height-medium);
+  }
+
+  .input--pill.input--large {
+    border-radius: var(--sl-input-height-large);
+  }
+
+  /*
+   * Clearable + Password Toggle
+   */
+
+  .input__clear,
+  .input__password-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: inherit;
+    color: var(--sl-input-icon-color);
+    border: none;
+    background: none;
+    padding: 0;
+    transition: var(--sl-transition-fast) color;
+    cursor: pointer;
+  }
+
+  .input__clear:hover,
+  .input__password-toggle:hover {
+    color: var(--sl-input-icon-color-hover);
+  }
+
+  .input__clear:focus,
+  .input__password-toggle:focus {
+    outline: none;
+  }
+
+  /* Don't show the browser's password toggle in Edge */
+  ::-ms-reveal {
+    display: none;
+  }
+
+  /* Hide the built-in number spinner */
+  .input--no-spin-buttons input[type='number']::-webkit-outer-spin-button,
+  .input--no-spin-buttons input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    display: none;
+  }
+
+  .input--no-spin-buttons input[type='number'] {
+    -moz-appearance: textfield;
+  }
+`,rt=class extends gt{constructor(){super(...arguments),this.formControlController=new bn(this,{assumeInteractionOn:["sl-blur","sl-input"]}),this.hasSlotController=new Ke(this,"help-text","label"),this.localize=new ve(this),this.hasFocus=!1,this.title="",this.__numberInput=Object.assign(document.createElement("input"),{type:"number"}),this.__dateInput=Object.assign(document.createElement("input"),{type:"date"}),this.type="text",this.name="",this.value="",this.defaultValue="",this.size="medium",this.filled=!1,this.pill=!1,this.label="",this.helpText="",this.clearable=!1,this.disabled=!1,this.placeholder="",this.readonly=!1,this.passwordToggle=!1,this.passwordVisible=!1,this.noSpinButtons=!1,this.form="",this.required=!1,this.spellcheck=!0}get valueAsDate(){var t;return this.__dateInput.type=this.type,this.__dateInput.value=this.value,((t=this.input)==null?void 0:t.valueAsDate)||this.__dateInput.valueAsDate}set valueAsDate(t){this.__dateInput.type=this.type,this.__dateInput.valueAsDate=t,this.value=this.__dateInput.value}get valueAsNumber(){var t;return this.__numberInput.value=this.value,((t=this.input)==null?void 0:t.valueAsNumber)||this.__numberInput.valueAsNumber}set valueAsNumber(t){this.__numberInput.valueAsNumber=t,this.value=this.__numberInput.value}get validity(){return this.input.validity}get validationMessage(){return this.input.validationMessage}firstUpdated(){this.formControlController.updateValidity()}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleChange(){this.value=this.input.value,this.emit("sl-change")}handleClearClick(t){t.preventDefault(),this.value!==""&&(this.value="",this.emit("sl-clear"),this.emit("sl-input"),this.emit("sl-change")),this.input.focus()}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleInput(){this.value=this.input.value,this.formControlController.updateValidity(),this.emit("sl-input")}handleInvalid(t){this.formControlController.setValidity(!1),this.formControlController.emitInvalidEvent(t)}handleKeyDown(t){const r=t.metaKey||t.ctrlKey||t.shiftKey||t.altKey;t.key==="Enter"&&!r&&setTimeout(()=>{!t.defaultPrevented&&!t.isComposing&&this.formControlController.submit()})}handlePasswordToggle(){this.passwordVisible=!this.passwordVisible}handleDisabledChange(){this.formControlController.setValidity(this.disabled)}handleStepChange(){this.input.step=String(this.step),this.formControlController.updateValidity()}async handleValueChange(){await this.updateComplete,this.formControlController.updateValidity()}focus(t){this.input.focus(t)}blur(){this.input.blur()}select(){this.input.select()}setSelectionRange(t,r,o="none"){this.input.setSelectionRange(t,r,o)}setRangeText(t,r,o,i="preserve"){const l=r??this.input.selectionStart,c=o??this.input.selectionEnd;this.input.setRangeText(t,l,c,i),this.value!==this.input.value&&(this.value=this.input.value)}showPicker(){"showPicker"in HTMLInputElement.prototype&&this.input.showPicker()}stepUp(){this.input.stepUp(),this.value!==this.input.value&&(this.value=this.input.value)}stepDown(){this.input.stepDown(),this.value!==this.input.value&&(this.value=this.input.value)}checkValidity(){return this.input.checkValidity()}getForm(){return this.formControlController.getForm()}reportValidity(){return this.input.reportValidity()}setCustomValidity(t){this.input.setCustomValidity(t),this.formControlController.updateValidity()}render(){const t=this.hasSlotController.test("label"),r=this.hasSlotController.test("help-text"),o=this.label?!0:!!t,i=this.helpText?!0:!!r,c=this.clearable&&!this.disabled&&!this.readonly&&(typeof this.value=="number"||this.value.length>0);return X`
+      <div
+        part="form-control"
+        class=${kt({"form-control":!0,"form-control--small":this.size==="small","form-control--medium":this.size==="medium","form-control--large":this.size==="large","form-control--has-label":o,"form-control--has-help-text":i})}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${o?"false":"true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${kt({input:!0,"input--small":this.size==="small","input--medium":this.size==="medium","input--large":this.size==="large","input--pill":this.pill,"input--standard":!this.filled,"input--filled":this.filled,"input--disabled":this.disabled,"input--focused":this.hasFocus,"input--empty":!this.value,"input--no-spin-buttons":this.noSpinButtons})}
+          >
+            <span part="prefix" class="input__prefix">
+              <slot name="prefix"></slot>
+            </span>
+
+            <input
+              part="input"
+              id="input"
+              class="input__control"
+              type=${this.type==="password"&&this.passwordVisible?"text":this.type}
+              title=${this.title}
+              name=${Y(this.name)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${Y(this.placeholder)}
+              minlength=${Y(this.minlength)}
+              maxlength=${Y(this.maxlength)}
+              min=${Y(this.min)}
+              max=${Y(this.max)}
+              step=${Y(this.step)}
+              .value=${io(this.value)}
+              autocapitalize=${Y(this.autocapitalize)}
+              autocomplete=${Y(this.autocomplete)}
+              autocorrect=${Y(this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${this.spellcheck}
+              pattern=${Y(this.pattern)}
+              enterkeyhint=${Y(this.enterkeyhint)}
+              inputmode=${Y(this.inputmode)}
+              aria-describedby="help-text"
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @invalid=${this.handleInvalid}
+              @keydown=${this.handleKeyDown}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            />
+
+            ${c?X`
+                  <button
+                    part="clear-button"
+                    class="input__clear"
+                    type="button"
+                    aria-label=${this.localize.term("clearEntry")}
+                    @click=${this.handleClearClick}
+                    tabindex="-1"
+                  >
+                    <slot name="clear-icon">
+                      <sl-icon name="x-circle-fill" library="system"></sl-icon>
+                    </slot>
+                  </button>
+                `:""}
+            ${this.passwordToggle&&!this.disabled?X`
+                  <button
+                    part="password-toggle-button"
+                    class="input__password-toggle"
+                    type="button"
+                    aria-label=${this.localize.term(this.passwordVisible?"hidePassword":"showPassword")}
+                    @click=${this.handlePasswordToggle}
+                    tabindex="-1"
+                  >
+                    ${this.passwordVisible?X`
+                          <slot name="show-password-icon">
+                            <sl-icon name="eye-slash" library="system"></sl-icon>
+                          </slot>
+                        `:X`
+                          <slot name="hide-password-icon">
+                            <sl-icon name="eye" library="system"></sl-icon>
+                          </slot>
+                        `}
+                  </button>
+                `:""}
+
+            <span part="suffix" class="input__suffix">
+              <slot name="suffix"></slot>
+            </span>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${i?"false":"true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `}};rt.styles=[St,go,bc];rt.dependencies={"sl-icon":Ut};f([st(".input__control")],rt.prototype,"input",2);f([_t()],rt.prototype,"hasFocus",2);f([C()],rt.prototype,"title",2);f([C({reflect:!0})],rt.prototype,"type",2);f([C()],rt.prototype,"name",2);f([C()],rt.prototype,"value",2);f([Li()],rt.prototype,"defaultValue",2);f([C({reflect:!0})],rt.prototype,"size",2);f([C({type:Boolean,reflect:!0})],rt.prototype,"filled",2);f([C({type:Boolean,reflect:!0})],rt.prototype,"pill",2);f([C()],rt.prototype,"label",2);f([C({attribute:"help-text"})],rt.prototype,"helpText",2);f([C({type:Boolean})],rt.prototype,"clearable",2);f([C({type:Boolean,reflect:!0})],rt.prototype,"disabled",2);f([C()],rt.prototype,"placeholder",2);f([C({type:Boolean,reflect:!0})],rt.prototype,"readonly",2);f([C({attribute:"password-toggle",type:Boolean})],rt.prototype,"passwordToggle",2);f([C({attribute:"password-visible",type:Boolean})],rt.prototype,"passwordVisible",2);f([C({attribute:"no-spin-buttons",type:Boolean})],rt.prototype,"noSpinButtons",2);f([C({reflect:!0})],rt.prototype,"form",2);f([C({type:Boolean,reflect:!0})],rt.prototype,"required",2);f([C()],rt.prototype,"pattern",2);f([C({type:Number})],rt.prototype,"minlength",2);f([C({type:Number})],rt.prototype,"maxlength",2);f([C()],rt.prototype,"min",2);f([C()],rt.prototype,"max",2);f([C()],rt.prototype,"step",2);f([C()],rt.prototype,"autocapitalize",2);f([C()],rt.prototype,"autocorrect",2);f([C()],rt.prototype,"autocomplete",2);f([C({type:Boolean})],rt.prototype,"autofocus",2);f([C()],rt.prototype,"enterkeyhint",2);f([C({type:Boolean,converter:{fromAttribute:t=>!(!t||t==="false"),toAttribute:t=>t?"true":"false"}})],rt.prototype,"spellcheck",2);f([C()],rt.prototype,"inputmode",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],rt.prototype,"handleDisabledChange",1);f([ht("step",{waitUntilFirstUpdate:!0})],rt.prototype,"handleStepChange",1);f([ht("value",{waitUntilFirstUpdate:!0})],rt.prototype,"handleValueChange",1);rt.define("sl-input");Nt.define("sl-icon-button");var mc=ct`
+  :host {
+    display: block;
+  }
+
+  .form-control {
+    position: relative;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .form-control__label {
+    padding: 0;
+  }
+
+  .radio-group--required .radio-group__label::after {
+    content: var(--sl-input-required-content);
+    margin-inline-start: var(--sl-input-required-content-offset);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+`,Mt=class extends gt{constructor(){super(...arguments),this.formControlController=new bn(this),this.hasSlotController=new Ke(this,"help-text","label"),this.customValidityMessage="",this.hasButtonGroup=!1,this.errorMessage="",this.defaultValue="",this.label="",this.helpText="",this.name="option",this.value="",this.size="medium",this.form="",this.required=!1}get validity(){const t=this.required&&!this.value;return this.customValidityMessage!==""?qu:t?Nu:bo}get validationMessage(){const t=this.required&&!this.value;return this.customValidityMessage!==""?this.customValidityMessage:t?this.validationInput.validationMessage:""}connectedCallback(){super.connectedCallback(),this.defaultValue=this.value}firstUpdated(){this.formControlController.updateValidity()}getAllRadios(){return[...this.querySelectorAll("sl-radio, sl-radio-button")]}handleRadioClick(t){const r=t.target.closest("sl-radio, sl-radio-button"),o=this.getAllRadios(),i=this.value;!r||r.disabled||(this.value=r.value,o.forEach(l=>l.checked=l===r),this.value!==i&&(this.emit("sl-change"),this.emit("sl-input")))}handleKeyDown(t){var r;if(!["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"," "].includes(t.key))return;const o=this.getAllRadios().filter(m=>!m.disabled),i=(r=o.find(m=>m.checked))!=null?r:o[0],l=t.key===" "?0:["ArrowUp","ArrowLeft"].includes(t.key)?-1:1,c=this.value;let h=o.indexOf(i)+l;h<0&&(h=o.length-1),h>o.length-1&&(h=0),this.getAllRadios().forEach(m=>{m.checked=!1,this.hasButtonGroup||m.setAttribute("tabindex","-1")}),this.value=o[h].value,o[h].checked=!0,this.hasButtonGroup?o[h].shadowRoot.querySelector("button").focus():(o[h].setAttribute("tabindex","0"),o[h].focus()),this.value!==c&&(this.emit("sl-change"),this.emit("sl-input")),t.preventDefault()}handleLabelClick(){this.focus()}handleInvalid(t){this.formControlController.setValidity(!1),this.formControlController.emitInvalidEvent(t)}async syncRadioElements(){var t,r;const o=this.getAllRadios();if(await Promise.all(o.map(async i=>{await i.updateComplete,i.checked=i.value===this.value,i.size=this.size})),this.hasButtonGroup=o.some(i=>i.tagName.toLowerCase()==="sl-radio-button"),o.length>0&&!o.some(i=>i.checked))if(this.hasButtonGroup){const i=(t=o[0].shadowRoot)==null?void 0:t.querySelector("button");i&&i.setAttribute("tabindex","0")}else o[0].setAttribute("tabindex","0");if(this.hasButtonGroup){const i=(r=this.shadowRoot)==null?void 0:r.querySelector("sl-button-group");i&&(i.disableRole=!0)}}syncRadios(){if(customElements.get("sl-radio")&&customElements.get("sl-radio-button")){this.syncRadioElements();return}customElements.get("sl-radio")?this.syncRadioElements():customElements.whenDefined("sl-radio").then(()=>this.syncRadios()),customElements.get("sl-radio-button")?this.syncRadioElements():customElements.whenDefined("sl-radio-button").then(()=>this.syncRadios())}updateCheckedRadio(){this.getAllRadios().forEach(r=>r.checked=r.value===this.value),this.formControlController.setValidity(this.validity.valid)}handleSizeChange(){this.syncRadios()}handleValueChange(){this.hasUpdated&&this.updateCheckedRadio()}checkValidity(){const t=this.required&&!this.value,r=this.customValidityMessage!=="";return t||r?(this.formControlController.emitInvalidEvent(),!1):!0}getForm(){return this.formControlController.getForm()}reportValidity(){const t=this.validity.valid;return this.errorMessage=this.customValidityMessage||t?"":this.validationInput.validationMessage,this.formControlController.setValidity(t),this.validationInput.hidden=!0,clearTimeout(this.validationTimeout),t||(this.validationInput.hidden=!1,this.validationInput.reportValidity(),this.validationTimeout=setTimeout(()=>this.validationInput.hidden=!0,1e4)),t}setCustomValidity(t=""){this.customValidityMessage=t,this.errorMessage=t,this.validationInput.setCustomValidity(t),this.formControlController.updateValidity()}focus(t){const r=this.getAllRadios(),o=r.find(c=>c.checked),i=r.find(c=>!c.disabled),l=o||i;l&&l.focus(t)}render(){const t=this.hasSlotController.test("label"),r=this.hasSlotController.test("help-text"),o=this.label?!0:!!t,i=this.helpText?!0:!!r,l=X`
+      <slot @slotchange=${this.syncRadios} @click=${this.handleRadioClick} @keydown=${this.handleKeyDown}></slot>
+    `;return X`
+      <fieldset
+        part="form-control"
+        class=${kt({"form-control":!0,"form-control--small":this.size==="small","form-control--medium":this.size==="medium","form-control--large":this.size==="large","form-control--radio-group":!0,"form-control--has-label":o,"form-control--has-help-text":i})}
+        role="radiogroup"
+        aria-labelledby="label"
+        aria-describedby="help-text"
+        aria-errormessage="error-message"
+      >
+        <label
+          part="form-control-label"
+          id="label"
+          class="form-control__label"
+          aria-hidden=${o?"false":"true"}
+          @click=${this.handleLabelClick}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div class="visually-hidden">
+            <div id="error-message" aria-live="assertive">${this.errorMessage}</div>
+            <label class="radio-group__validation">
+              <input
+                type="text"
+                class="radio-group__validation-input"
+                ?required=${this.required}
+                tabindex="-1"
+                hidden
+                @invalid=${this.handleInvalid}
+              />
+            </label>
+          </div>
+
+          ${this.hasButtonGroup?X`
+                <sl-button-group part="button-group" exportparts="base:button-group__base" role="presentation">
+                  ${l}
+                </sl-button-group>
+              `:l}
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${i?"false":"true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </fieldset>
+    `}};Mt.styles=[St,go,mc];Mt.dependencies={"sl-button-group":Or};f([st("slot:not([name])")],Mt.prototype,"defaultSlot",2);f([st(".radio-group__validation-input")],Mt.prototype,"validationInput",2);f([_t()],Mt.prototype,"hasButtonGroup",2);f([_t()],Mt.prototype,"errorMessage",2);f([_t()],Mt.prototype,"defaultValue",2);f([C()],Mt.prototype,"label",2);f([C({attribute:"help-text"})],Mt.prototype,"helpText",2);f([C()],Mt.prototype,"name",2);f([C({reflect:!0})],Mt.prototype,"value",2);f([C({reflect:!0})],Mt.prototype,"size",2);f([C({reflect:!0})],Mt.prototype,"form",2);f([C({type:Boolean,reflect:!0})],Mt.prototype,"required",2);f([ht("size",{waitUntilFirstUpdate:!0})],Mt.prototype,"handleSizeChange",1);f([ht("value")],Mt.prototype,"handleValueChange",1);Mt.define("sl-radio-group");var vc=ct`
+  ${Ca}
+
+  .button__prefix,
+  .button__suffix,
+  .button__label {
+    display: inline-flex;
+    position: relative;
+    align-items: center;
+  }
+
+  /* We use a hidden input so constraint validation errors work, since they don't appear to show when used with buttons.
+    We can't actually hide it, though, otherwise the messages will be suppressed by the browser. */
+  .hidden-input {
+    all: unset;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    outline: dotted 1px red;
+    opacity: 0;
+    z-index: -1;
+  }
+`,ce=class extends gt{constructor(){super(...arguments),this.hasSlotController=new Ke(this,"[default]","prefix","suffix"),this.hasFocus=!1,this.checked=!1,this.disabled=!1,this.size="medium",this.pill=!1}connectedCallback(){super.connectedCallback(),this.setAttribute("role","presentation")}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleClick(t){if(this.disabled){t.preventDefault(),t.stopPropagation();return}this.checked=!0}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleDisabledChange(){this.setAttribute("aria-disabled",this.disabled?"true":"false")}focus(t){this.input.focus(t)}blur(){this.input.blur()}render(){return an`
+      <div part="base" role="presentation">
+        <button
+          part="${`button${this.checked?" button--checked":""}`}"
+          role="radio"
+          aria-checked="${this.checked}"
+          class=${kt({button:!0,"button--default":!0,"button--small":this.size==="small","button--medium":this.size==="medium","button--large":this.size==="large","button--checked":this.checked,"button--disabled":this.disabled,"button--focused":this.hasFocus,"button--outline":!0,"button--pill":this.pill,"button--has-label":this.hasSlotController.test("[default]"),"button--has-prefix":this.hasSlotController.test("prefix"),"button--has-suffix":this.hasSlotController.test("suffix")})}
+          aria-disabled=${this.disabled}
+          type="button"
+          value=${Y(this.value)}
+          @blur=${this.handleBlur}
+          @focus=${this.handleFocus}
+          @click=${this.handleClick}
+        >
+          <slot name="prefix" part="prefix" class="button__prefix"></slot>
+          <slot part="label" class="button__label"></slot>
+          <slot name="suffix" part="suffix" class="button__suffix"></slot>
+        </button>
+      </div>
+    `}};ce.styles=[St,vc];f([st(".button")],ce.prototype,"input",2);f([st(".hidden-input")],ce.prototype,"hiddenInput",2);f([_t()],ce.prototype,"hasFocus",2);f([C({type:Boolean,reflect:!0})],ce.prototype,"checked",2);f([C()],ce.prototype,"value",2);f([C({type:Boolean,reflect:!0})],ce.prototype,"disabled",2);f([C({reflect:!0})],ce.prototype,"size",2);f([C({type:Boolean,reflect:!0})],ce.prototype,"pill",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],ce.prototype,"handleDisabledChange",1);ce.define("sl-radio-button");var gc=ct`
+  :host {
+    display: inline-block;
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-small);
+    font-weight: var(--sl-font-weight-semibold);
+    border-radius: var(--sl-border-radius-medium);
+    color: var(--sl-color-neutral-600);
+    padding: var(--sl-spacing-medium) var(--sl-spacing-large);
+    white-space: nowrap;
+    user-select: none;
+    -webkit-user-select: none;
+    cursor: pointer;
+    transition:
+      var(--transition-speed) box-shadow,
+      var(--transition-speed) color;
+  }
+
+  .tab:hover:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  :host(:focus) {
+    outline: transparent;
+  }
+
+  :host(:focus-visible) {
+    color: var(--sl-color-primary-600);
+    outline: var(--sl-focus-ring);
+    outline-offset: calc(-1 * var(--sl-focus-ring-width) - var(--sl-focus-ring-offset));
+  }
+
+  .tab.tab--active:not(.tab--disabled) {
+    color: var(--sl-color-primary-600);
+  }
+
+  .tab.tab--closable {
+    padding-inline-end: var(--sl-spacing-small);
+  }
+
+  .tab.tab--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .tab__close-button {
+    font-size: var(--sl-font-size-small);
+    margin-inline-start: var(--sl-spacing-small);
+  }
+
+  .tab__close-button::part(base) {
+    padding: var(--sl-spacing-3x-small);
+  }
+
+  @media (forced-colors: active) {
+    .tab.tab--active:not(.tab--disabled) {
+      outline: solid 1px transparent;
+      outline-offset: -3px;
+    }
+  }
+`,yc=0,de=class extends gt{constructor(){super(...arguments),this.localize=new ve(this),this.attrId=++yc,this.componentId=`sl-tab-${this.attrId}`,this.panel="",this.active=!1,this.closable=!1,this.disabled=!1,this.tabIndex=0}connectedCallback(){super.connectedCallback(),this.setAttribute("role","tab")}handleCloseClick(t){t.stopPropagation(),this.emit("sl-close")}handleActiveChange(){this.setAttribute("aria-selected",this.active?"true":"false")}handleDisabledChange(){this.setAttribute("aria-disabled",this.disabled?"true":"false"),this.disabled&&!this.active?this.tabIndex=-1:this.tabIndex=0}render(){return this.id=this.id.length>0?this.id:this.componentId,X`
+      <div
+        part="base"
+        class=${kt({tab:!0,"tab--active":this.active,"tab--closable":this.closable,"tab--disabled":this.disabled})}
+      >
+        <slot></slot>
+        ${this.closable?X`
+              <sl-icon-button
+                part="close-button"
+                exportparts="base:close-button__base"
+                name="x-lg"
+                library="system"
+                label=${this.localize.term("close")}
+                class="tab__close-button"
+                @click=${this.handleCloseClick}
+                tabindex="-1"
+              ></sl-icon-button>
+            `:""}
+      </div>
+    `}};de.styles=[St,gc];de.dependencies={"sl-icon-button":Nt};f([st(".tab")],de.prototype,"tab",2);f([C({reflect:!0})],de.prototype,"panel",2);f([C({type:Boolean,reflect:!0})],de.prototype,"active",2);f([C({type:Boolean,reflect:!0})],de.prototype,"closable",2);f([C({type:Boolean,reflect:!0})],de.prototype,"disabled",2);f([C({type:Number,reflect:!0})],de.prototype,"tabIndex",2);f([ht("active")],de.prototype,"handleActiveChange",1);f([ht("disabled")],de.prototype,"handleDisabledChange",1);de.define("sl-tab");var wc=ct`
+  :host {
+    --indicator-color: var(--sl-color-primary-600);
+    --track-color: var(--sl-color-neutral-200);
+    --track-width: 2px;
+
+    display: block;
+  }
+
+  .tab-group {
+    display: flex;
+    border-radius: 0;
+  }
+
+  .tab-group__tabs {
+    display: flex;
+    position: relative;
+  }
+
+  .tab-group__indicator {
+    position: absolute;
+    transition:
+      var(--sl-transition-fast) translate ease,
+      var(--sl-transition-fast) width ease;
+  }
+
+  .tab-group--has-scroll-controls .tab-group__nav-container {
+    position: relative;
+    padding: 0 var(--sl-spacing-x-large);
+  }
+
+  .tab-group--has-scroll-controls .tab-group__scroll-button--start--hidden,
+  .tab-group--has-scroll-controls .tab-group__scroll-button--end--hidden {
+    visibility: hidden;
+  }
+
+  .tab-group__body {
+    display: block;
+    overflow: auto;
+  }
+
+  .tab-group__scroll-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--sl-spacing-x-large);
+  }
+
+  .tab-group__scroll-button--start {
+    left: 0;
+  }
+
+  .tab-group__scroll-button--end {
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--start {
+    left: auto;
+    right: 0;
+  }
+
+  .tab-group--rtl .tab-group__scroll-button--end {
+    left: 0;
+    right: auto;
+  }
+
+  /*
+   * Top
+   */
+
+  .tab-group--top {
+    flex-direction: column;
+  }
+
+  .tab-group--top .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--top .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--top .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--top .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-bottom: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--top .tab-group__indicator {
+    bottom: calc(-1 * var(--track-width));
+    border-bottom: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--top .tab-group__body {
+    order: 2;
+  }
+
+  .tab-group--top ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Bottom
+   */
+
+  .tab-group--bottom {
+    flex-direction: column;
+  }
+
+  .tab-group--bottom .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--bottom .tab-group__nav {
+    display: flex;
+    overflow-x: auto;
+
+    /* Hide scrollbar in Firefox */
+    scrollbar-width: none;
+  }
+
+  /* Hide scrollbar in Chrome/Safari */
+  .tab-group--bottom .tab-group__nav::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .tab-group--bottom .tab-group__tabs {
+    flex: 1 1 auto;
+    position: relative;
+    flex-direction: row;
+    border-top: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--bottom .tab-group__indicator {
+    top: calc(-1 * var(--track-width));
+    border-top: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--bottom .tab-group__body {
+    order: 1;
+  }
+
+  .tab-group--bottom ::slotted(sl-tab-panel) {
+    --padding: var(--sl-spacing-medium) 0;
+  }
+
+  /*
+   * Start
+   */
+
+  .tab-group--start {
+    flex-direction: row;
+  }
+
+  .tab-group--start .tab-group__nav-container {
+    order: 1;
+  }
+
+  .tab-group--start .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-inline-end: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--start .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    border-right: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--start.tab-group--rtl .tab-group__indicator {
+    right: auto;
+    left: calc(-1 * var(--track-width));
+  }
+
+  .tab-group--start .tab-group__body {
+    flex: 1 1 auto;
+    order: 2;
+  }
+
+  .tab-group--start ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+
+  /*
+   * End
+   */
+
+  .tab-group--end {
+    flex-direction: row;
+  }
+
+  .tab-group--end .tab-group__nav-container {
+    order: 2;
+  }
+
+  .tab-group--end .tab-group__tabs {
+    flex: 0 0 auto;
+    flex-direction: column;
+    border-left: solid var(--track-width) var(--track-color);
+  }
+
+  .tab-group--end .tab-group__indicator {
+    left: calc(-1 * var(--track-width));
+    border-inline-start: solid var(--track-width) var(--indicator-color);
+  }
+
+  .tab-group--end.tab-group--rtl .tab-group__indicator {
+    right: calc(-1 * var(--track-width));
+    left: auto;
+  }
+
+  .tab-group--end .tab-group__body {
+    flex: 1 1 auto;
+    order: 1;
+  }
+
+  .tab-group--end ::slotted(sl-tab-panel) {
+    --padding: 0 var(--sl-spacing-medium);
+  }
+`,_c=ct`
+  :host {
+    display: contents;
+  }
+`,wo=class extends gt{constructor(){super(...arguments),this.observedElements=[],this.disabled=!1}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(t=>{this.emit("sl-resize",{detail:{entries:t}})}),this.disabled||this.startObserver()}disconnectedCallback(){super.disconnectedCallback(),this.stopObserver()}handleSlotChange(){this.disabled||this.startObserver()}startObserver(){const t=this.shadowRoot.querySelector("slot");if(t!==null){const r=t.assignedElements({flatten:!0});this.observedElements.forEach(o=>this.resizeObserver.unobserve(o)),this.observedElements=[],r.forEach(o=>{this.resizeObserver.observe(o),this.observedElements.push(o)})}}stopObserver(){this.resizeObserver.disconnect()}handleDisabledChange(){this.disabled?this.stopObserver():this.startObserver()}render(){return X` <slot @slotchange=${this.handleSlotChange}></slot> `}};wo.styles=[St,_c];f([C({type:Boolean,reflect:!0})],wo.prototype,"disabled",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],wo.prototype,"handleDisabledChange",1);var Dt=class extends gt{constructor(){super(...arguments),this.tabs=[],this.focusableTabs=[],this.panels=[],this.localize=new ve(this),this.hasScrollControls=!1,this.shouldHideScrollStartButton=!1,this.shouldHideScrollEndButton=!1,this.placement="top",this.activation="auto",this.noScrollControls=!1,this.fixedScrollControls=!1,this.scrollOffset=1}connectedCallback(){const t=Promise.all([customElements.whenDefined("sl-tab"),customElements.whenDefined("sl-tab-panel")]);super.connectedCallback(),this.resizeObserver=new ResizeObserver(()=>{this.repositionIndicator(),this.updateScrollControls()}),this.mutationObserver=new MutationObserver(r=>{const o=r.filter(({target:i})=>{if(i===this)return!0;if(i.closest("sl-tab-group")!==this)return!1;const l=i.tagName.toLowerCase();return l==="sl-tab"||l==="sl-tab-panel"});if(o.length!==0){if(o.some(i=>!["aria-labelledby","aria-controls"].includes(i.attributeName))&&setTimeout(()=>this.setAriaLabels()),o.some(i=>i.attributeName==="disabled"))this.syncTabsAndPanels();else if(o.some(i=>i.attributeName==="active")){const l=o.filter(c=>c.attributeName==="active"&&c.target.tagName.toLowerCase()==="sl-tab").map(c=>c.target).find(c=>c.active);l&&this.setActiveTab(l)}}}),this.updateComplete.then(()=>{this.syncTabsAndPanels(),this.mutationObserver.observe(this,{attributes:!0,attributeFilter:["active","disabled","name","panel"],childList:!0,subtree:!0}),this.resizeObserver.observe(this.nav),t.then(()=>{new IntersectionObserver((o,i)=>{var l;o[0].intersectionRatio>0&&(this.setAriaLabels(),this.setActiveTab((l=this.getActiveTab())!=null?l:this.tabs[0],{emitEvents:!1}),i.unobserve(o[0].target))}).observe(this.tabGroup)})})}disconnectedCallback(){var t,r;super.disconnectedCallback(),(t=this.mutationObserver)==null||t.disconnect(),this.nav&&((r=this.resizeObserver)==null||r.unobserve(this.nav))}getAllTabs(){return this.shadowRoot.querySelector('slot[name="nav"]').assignedElements()}getAllPanels(){return[...this.body.assignedElements()].filter(t=>t.tagName.toLowerCase()==="sl-tab-panel")}getActiveTab(){return this.tabs.find(t=>t.active)}handleClick(t){const o=t.target.closest("sl-tab");o?.closest("sl-tab-group")===this&&o!==null&&this.setActiveTab(o,{scrollBehavior:"smooth"})}handleKeyDown(t){const o=t.target.closest("sl-tab");if(o?.closest("sl-tab-group")===this&&(["Enter"," "].includes(t.key)&&o!==null&&(this.setActiveTab(o,{scrollBehavior:"smooth"}),t.preventDefault()),["ArrowLeft","ArrowRight","ArrowUp","ArrowDown","Home","End"].includes(t.key))){const l=this.tabs.find(m=>m.matches(":focus")),c=this.localize.dir()==="rtl";let h=null;if(l?.tagName.toLowerCase()==="sl-tab"){if(t.key==="Home")h=this.focusableTabs[0];else if(t.key==="End")h=this.focusableTabs[this.focusableTabs.length-1];else if(["top","bottom"].includes(this.placement)&&t.key===(c?"ArrowRight":"ArrowLeft")||["start","end"].includes(this.placement)&&t.key==="ArrowUp"){const m=this.tabs.findIndex(k=>k===l);h=this.findNextFocusableTab(m,"backward")}else if(["top","bottom"].includes(this.placement)&&t.key===(c?"ArrowLeft":"ArrowRight")||["start","end"].includes(this.placement)&&t.key==="ArrowDown"){const m=this.tabs.findIndex(k=>k===l);h=this.findNextFocusableTab(m,"forward")}if(!h)return;h.tabIndex=0,h.focus({preventScroll:!0}),this.activation==="auto"?this.setActiveTab(h,{scrollBehavior:"smooth"}):this.tabs.forEach(m=>{m.tabIndex=m===h?0:-1}),["top","bottom"].includes(this.placement)&&Zs(h,this.nav,"horizontal"),t.preventDefault()}}}handleScrollToStart(){this.nav.scroll({left:this.localize.dir()==="rtl"?this.nav.scrollLeft+this.nav.clientWidth:this.nav.scrollLeft-this.nav.clientWidth,behavior:"smooth"})}handleScrollToEnd(){this.nav.scroll({left:this.localize.dir()==="rtl"?this.nav.scrollLeft-this.nav.clientWidth:this.nav.scrollLeft+this.nav.clientWidth,behavior:"smooth"})}setActiveTab(t,r){if(r=je({emitEvents:!0,scrollBehavior:"auto"},r),t!==this.activeTab&&!t.disabled){const o=this.activeTab;this.activeTab=t,this.tabs.forEach(i=>{i.active=i===this.activeTab,i.tabIndex=i===this.activeTab?0:-1}),this.panels.forEach(i=>{var l;return i.active=i.name===((l=this.activeTab)==null?void 0:l.panel)}),this.syncIndicator(),["top","bottom"].includes(this.placement)&&Zs(this.activeTab,this.nav,"horizontal",r.scrollBehavior),r.emitEvents&&(o&&this.emit("sl-tab-hide",{detail:{name:o.panel}}),this.emit("sl-tab-show",{detail:{name:this.activeTab.panel}}))}}setAriaLabels(){this.tabs.forEach(t=>{const r=this.panels.find(o=>o.name===t.panel);r&&(t.setAttribute("aria-controls",r.getAttribute("id")),r.setAttribute("aria-labelledby",t.getAttribute("id")))})}repositionIndicator(){const t=this.getActiveTab();if(!t)return;const r=t.clientWidth,o=t.clientHeight,i=this.localize.dir()==="rtl",l=this.getAllTabs(),h=l.slice(0,l.indexOf(t)).reduce((m,k)=>({left:m.left+k.clientWidth,top:m.top+k.clientHeight}),{left:0,top:0});switch(this.placement){case"top":case"bottom":this.indicator.style.width=`${r}px`,this.indicator.style.height="auto",this.indicator.style.translate=i?`${-1*h.left}px`:`${h.left}px`;break;case"start":case"end":this.indicator.style.width="auto",this.indicator.style.height=`${o}px`,this.indicator.style.translate=`0 ${h.top}px`;break}}syncTabsAndPanels(){this.tabs=this.getAllTabs(),this.focusableTabs=this.tabs.filter(t=>!t.disabled),this.panels=this.getAllPanels(),this.syncIndicator(),this.updateComplete.then(()=>this.updateScrollControls())}findNextFocusableTab(t,r){let o=null;const i=r==="forward"?1:-1;let l=t+i;for(;t<this.tabs.length;){if(o=this.tabs[l]||null,o===null){r==="forward"?o=this.focusableTabs[0]:o=this.focusableTabs[this.focusableTabs.length-1];break}if(!o.disabled)break;l+=i}return o}updateScrollButtons(){this.hasScrollControls&&!this.fixedScrollControls&&(this.shouldHideScrollStartButton=this.scrollFromStart()<=this.scrollOffset,this.shouldHideScrollEndButton=this.isScrolledToEnd())}isScrolledToEnd(){return this.scrollFromStart()+this.nav.clientWidth>=this.nav.scrollWidth-this.scrollOffset}scrollFromStart(){return this.localize.dir()==="rtl"?-this.nav.scrollLeft:this.nav.scrollLeft}updateScrollControls(){this.noScrollControls?this.hasScrollControls=!1:this.hasScrollControls=["top","bottom"].includes(this.placement)&&this.nav.scrollWidth>this.nav.clientWidth+1,this.updateScrollButtons()}syncIndicator(){this.getActiveTab()?(this.indicator.style.display="block",this.repositionIndicator()):this.indicator.style.display="none"}show(t){const r=this.tabs.find(o=>o.panel===t);r&&this.setActiveTab(r,{scrollBehavior:"smooth"})}render(){const t=this.localize.dir()==="rtl";return X`
+      <div
+        part="base"
+        class=${kt({"tab-group":!0,"tab-group--top":this.placement==="top","tab-group--bottom":this.placement==="bottom","tab-group--start":this.placement==="start","tab-group--end":this.placement==="end","tab-group--rtl":this.localize.dir()==="rtl","tab-group--has-scroll-controls":this.hasScrollControls})}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+      >
+        <div class="tab-group__nav-container" part="nav">
+          ${this.hasScrollControls?X`
+                <sl-icon-button
+                  part="scroll-button scroll-button--start"
+                  exportparts="base:scroll-button__base"
+                  class=${kt({"tab-group__scroll-button":!0,"tab-group__scroll-button--start":!0,"tab-group__scroll-button--start--hidden":this.shouldHideScrollStartButton})}
+                  name=${t?"chevron-right":"chevron-left"}
+                  library="system"
+                  tabindex="-1"
+                  aria-hidden="true"
+                  label=${this.localize.term("scrollToStart")}
+                  @click=${this.handleScrollToStart}
+                ></sl-icon-button>
+              `:""}
+
+          <div class="tab-group__nav" @scrollend=${this.updateScrollButtons}>
+            <div part="tabs" class="tab-group__tabs" role="tablist">
+              <div part="active-tab-indicator" class="tab-group__indicator"></div>
+              <sl-resize-observer @sl-resize=${this.syncIndicator}>
+                <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>
+              </sl-resize-observer>
+            </div>
+          </div>
+
+          ${this.hasScrollControls?X`
+                <sl-icon-button
+                  part="scroll-button scroll-button--end"
+                  exportparts="base:scroll-button__base"
+                  class=${kt({"tab-group__scroll-button":!0,"tab-group__scroll-button--end":!0,"tab-group__scroll-button--end--hidden":this.shouldHideScrollEndButton})}
+                  name=${t?"chevron-left":"chevron-right"}
+                  library="system"
+                  tabindex="-1"
+                  aria-hidden="true"
+                  label=${this.localize.term("scrollToEnd")}
+                  @click=${this.handleScrollToEnd}
+                ></sl-icon-button>
+              `:""}
+        </div>
+
+        <slot part="body" class="tab-group__body" @slotchange=${this.syncTabsAndPanels}></slot>
+      </div>
+    `}};Dt.styles=[St,wc];Dt.dependencies={"sl-icon-button":Nt,"sl-resize-observer":wo};f([st(".tab-group")],Dt.prototype,"tabGroup",2);f([st(".tab-group__body")],Dt.prototype,"body",2);f([st(".tab-group__nav")],Dt.prototype,"nav",2);f([st(".tab-group__indicator")],Dt.prototype,"indicator",2);f([_t()],Dt.prototype,"hasScrollControls",2);f([_t()],Dt.prototype,"shouldHideScrollStartButton",2);f([_t()],Dt.prototype,"shouldHideScrollEndButton",2);f([C()],Dt.prototype,"placement",2);f([C()],Dt.prototype,"activation",2);f([C({attribute:"no-scroll-controls",type:Boolean})],Dt.prototype,"noScrollControls",2);f([C({attribute:"fixed-scroll-controls",type:Boolean})],Dt.prototype,"fixedScrollControls",2);f([Ul({passive:!0})],Dt.prototype,"updateScrollButtons",1);f([ht("noScrollControls",{waitUntilFirstUpdate:!0})],Dt.prototype,"updateScrollControls",1);f([ht("placement",{waitUntilFirstUpdate:!0})],Dt.prototype,"syncIndicator",1);Dt.define("sl-tab-group");var xc=(t,r)=>{let o=0;return function(...i){window.clearTimeout(o),o=window.setTimeout(()=>{t.call(this,...i)},r)}},ea=(t,r,o)=>{const i=t[r];t[r]=function(...l){i.call(this,...l),o.call(this,i,...l)}};(()=>{if(typeof window>"u")return;if(!("onscrollend"in window)){const r=new Set,o=new WeakMap,i=c=>{for(const h of c.changedTouches)r.add(h.identifier)},l=c=>{for(const h of c.changedTouches)r.delete(h.identifier)};document.addEventListener("touchstart",i,!0),document.addEventListener("touchend",l,!0),document.addEventListener("touchcancel",l,!0),ea(EventTarget.prototype,"addEventListener",function(c,h){if(h!=="scrollend")return;const m=xc(()=>{r.size?m():this.dispatchEvent(new Event("scrollend"))},100);c.call(this,"scroll",m,{passive:!0}),o.set(this,m)}),ea(EventTarget.prototype,"removeEventListener",function(c,h){if(h!=="scrollend")return;const m=o.get(this);m&&c.call(this,"scroll",m,{passive:!0})})}})();var kc=ct`
+  :host {
+    --padding: 0;
+
+    display: none;
+  }
+
+  :host([active]) {
+    display: block;
+  }
+
+  .tab-panel {
+    display: block;
+    padding: var(--padding);
+  }
+`,Cc=0,mn=class extends gt{constructor(){super(...arguments),this.attrId=++Cc,this.componentId=`sl-tab-panel-${this.attrId}`,this.name="",this.active=!1}connectedCallback(){super.connectedCallback(),this.id=this.id.length>0?this.id:this.componentId,this.setAttribute("role","tabpanel")}handleActiveChange(){this.setAttribute("aria-hidden",this.active?"false":"true")}render(){return X`
+      <slot
+        part="base"
+        class=${kt({"tab-panel":!0,"tab-panel--active":this.active})}
+      ></slot>
+    `}};mn.styles=[St,kc];f([C({reflect:!0})],mn.prototype,"name",2);f([C({type:Boolean,reflect:!0})],mn.prototype,"active",2);f([ht("active")],mn.prototype,"handleActiveChange",1);mn.define("sl-tab-panel");var $c=ct`
+  :host {
+    display: block;
+  }
+
+  .textarea {
+    display: grid;
+    align-items: center;
+    position: relative;
+    width: 100%;
+    font-family: var(--sl-input-font-family);
+    font-weight: var(--sl-input-font-weight);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-input-letter-spacing);
+    vertical-align: middle;
+    transition:
+      var(--sl-transition-fast) color,
+      var(--sl-transition-fast) border,
+      var(--sl-transition-fast) box-shadow,
+      var(--sl-transition-fast) background-color;
+    cursor: text;
+  }
+
+  /* Standard textareas */
+  .textarea--standard {
+    background-color: var(--sl-input-background-color);
+    border: solid var(--sl-input-border-width) var(--sl-input-border-color);
+  }
+
+  .textarea--standard:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-hover);
+    border-color: var(--sl-input-border-color-hover);
+  }
+  .textarea--standard:hover:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-hover);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-background-color-focus);
+    border-color: var(--sl-input-border-color-focus);
+    color: var(--sl-input-color-focus);
+    box-shadow: 0 0 0 var(--sl-focus-ring-width) var(--sl-input-focus-ring-color);
+  }
+
+  .textarea--standard.textarea--focused:not(.textarea--disabled) .textarea__control {
+    color: var(--sl-input-color-focus);
+  }
+
+  .textarea--standard.textarea--disabled {
+    background-color: var(--sl-input-background-color-disabled);
+    border-color: var(--sl-input-border-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea__control,
+  .textarea__size-adjuster {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+
+  .textarea__size-adjuster {
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control {
+    color: var(--sl-input-color-disabled);
+  }
+
+  .textarea--standard.textarea--disabled .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color-disabled);
+  }
+
+  /* Filled textareas */
+  .textarea--filled {
+    border: none;
+    background-color: var(--sl-input-filled-background-color);
+    color: var(--sl-input-color);
+  }
+
+  .textarea--filled:hover:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-hover);
+  }
+
+  .textarea--filled.textarea--focused:not(.textarea--disabled) {
+    background-color: var(--sl-input-filled-background-color-focus);
+    outline: var(--sl-focus-ring);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
+  .textarea--filled.textarea--disabled {
+    background-color: var(--sl-input-filled-background-color-disabled);
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .textarea__control {
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: 1.4;
+    color: var(--sl-input-color);
+    border: none;
+    background: none;
+    box-shadow: none;
+    cursor: inherit;
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::-webkit-search-decoration,
+  .textarea__control::-webkit-search-cancel-button,
+  .textarea__control::-webkit-search-results-button,
+  .textarea__control::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+  }
+
+  .textarea__control::placeholder {
+    color: var(--sl-input-placeholder-color);
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  .textarea__control:focus {
+    outline: none;
+  }
+
+  /*
+   * Size modifiers
+   */
+
+  .textarea--small {
+    border-radius: var(--sl-input-border-radius-small);
+    font-size: var(--sl-input-font-size-small);
+  }
+
+  .textarea--small .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-small);
+  }
+
+  .textarea--medium {
+    border-radius: var(--sl-input-border-radius-medium);
+    font-size: var(--sl-input-font-size-medium);
+  }
+
+  .textarea--medium .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-medium);
+  }
+
+  .textarea--large {
+    border-radius: var(--sl-input-border-radius-large);
+    font-size: var(--sl-input-font-size-large);
+  }
+
+  .textarea--large .textarea__control {
+    padding: 0.5em var(--sl-input-spacing-large);
+  }
+
+  /*
+   * Resize types
+   */
+
+  .textarea--resize-none .textarea__control {
+    resize: none;
+  }
+
+  .textarea--resize-vertical .textarea__control {
+    resize: vertical;
+  }
+
+  .textarea--resize-auto .textarea__control {
+    height: auto;
+    resize: none;
+    overflow-y: hidden;
+  }
+`,lt=class extends gt{constructor(){super(...arguments),this.formControlController=new bn(this,{assumeInteractionOn:["sl-blur","sl-input"]}),this.hasSlotController=new Ke(this,"help-text","label"),this.hasFocus=!1,this.title="",this.name="",this.value="",this.size="medium",this.filled=!1,this.label="",this.helpText="",this.placeholder="",this.rows=4,this.resize="vertical",this.disabled=!1,this.readonly=!1,this.form="",this.required=!1,this.spellcheck=!0,this.defaultValue=""}get validity(){return this.input.validity}get validationMessage(){return this.input.validationMessage}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(()=>this.setTextareaHeight()),this.updateComplete.then(()=>{this.setTextareaHeight(),this.resizeObserver.observe(this.input)})}firstUpdated(){this.formControlController.updateValidity()}disconnectedCallback(){var t;super.disconnectedCallback(),this.input&&((t=this.resizeObserver)==null||t.unobserve(this.input))}handleBlur(){this.hasFocus=!1,this.emit("sl-blur")}handleChange(){this.value=this.input.value,this.setTextareaHeight(),this.emit("sl-change")}handleFocus(){this.hasFocus=!0,this.emit("sl-focus")}handleInput(){this.value=this.input.value,this.emit("sl-input")}handleInvalid(t){this.formControlController.setValidity(!1),this.formControlController.emitInvalidEvent(t)}setTextareaHeight(){this.resize==="auto"?(this.sizeAdjuster.style.height=`${this.input.clientHeight}px`,this.input.style.height="auto",this.input.style.height=`${this.input.scrollHeight}px`):this.input.style.height=""}handleDisabledChange(){this.formControlController.setValidity(this.disabled)}handleRowsChange(){this.setTextareaHeight()}async handleValueChange(){await this.updateComplete,this.formControlController.updateValidity(),this.setTextareaHeight()}focus(t){this.input.focus(t)}blur(){this.input.blur()}select(){this.input.select()}scrollPosition(t){if(t){typeof t.top=="number"&&(this.input.scrollTop=t.top),typeof t.left=="number"&&(this.input.scrollLeft=t.left);return}return{top:this.input.scrollTop,left:this.input.scrollTop}}setSelectionRange(t,r,o="none"){this.input.setSelectionRange(t,r,o)}setRangeText(t,r,o,i="preserve"){const l=r??this.input.selectionStart,c=o??this.input.selectionEnd;this.input.setRangeText(t,l,c,i),this.value!==this.input.value&&(this.value=this.input.value,this.setTextareaHeight())}checkValidity(){return this.input.checkValidity()}getForm(){return this.formControlController.getForm()}reportValidity(){return this.input.reportValidity()}setCustomValidity(t){this.input.setCustomValidity(t),this.formControlController.updateValidity()}render(){const t=this.hasSlotController.test("label"),r=this.hasSlotController.test("help-text"),o=this.label?!0:!!t,i=this.helpText?!0:!!r;return X`
+      <div
+        part="form-control"
+        class=${kt({"form-control":!0,"form-control--small":this.size==="small","form-control--medium":this.size==="medium","form-control--large":this.size==="large","form-control--has-label":o,"form-control--has-help-text":i})}
+      >
+        <label
+          part="form-control-label"
+          class="form-control__label"
+          for="input"
+          aria-hidden=${o?"false":"true"}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" class="form-control-input">
+          <div
+            part="base"
+            class=${kt({textarea:!0,"textarea--small":this.size==="small","textarea--medium":this.size==="medium","textarea--large":this.size==="large","textarea--standard":!this.filled,"textarea--filled":this.filled,"textarea--disabled":this.disabled,"textarea--focused":this.hasFocus,"textarea--empty":!this.value,"textarea--resize-none":this.resize==="none","textarea--resize-vertical":this.resize==="vertical","textarea--resize-auto":this.resize==="auto"})}
+          >
+            <textarea
+              part="textarea"
+              id="input"
+              class="textarea__control"
+              title=${this.title}
+              name=${Y(this.name)}
+              .value=${io(this.value)}
+              ?disabled=${this.disabled}
+              ?readonly=${this.readonly}
+              ?required=${this.required}
+              placeholder=${Y(this.placeholder)}
+              rows=${Y(this.rows)}
+              minlength=${Y(this.minlength)}
+              maxlength=${Y(this.maxlength)}
+              autocapitalize=${Y(this.autocapitalize)}
+              autocorrect=${Y(this.autocorrect)}
+              ?autofocus=${this.autofocus}
+              spellcheck=${Y(this.spellcheck)}
+              enterkeyhint=${Y(this.enterkeyhint)}
+              inputmode=${Y(this.inputmode)}
+              aria-describedby="help-text"
+              @change=${this.handleChange}
+              @input=${this.handleInput}
+              @invalid=${this.handleInvalid}
+              @focus=${this.handleFocus}
+              @blur=${this.handleBlur}
+            ></textarea>
+            \x3C!-- This "adjuster" exists to prevent layout shifting. https://github.com/shoelace-style/shoelace/issues/2180 -->
+            <div part="textarea-adjuster" class="textarea__size-adjuster" ?hidden=${this.resize!=="auto"}></div>
+          </div>
+        </div>
+
+        <div
+          part="form-control-help-text"
+          id="help-text"
+          class="form-control__help-text"
+          aria-hidden=${i?"false":"true"}
+        >
+          <slot name="help-text">${this.helpText}</slot>
+        </div>
+      </div>
+    `}};lt.styles=[St,go,$c];f([st(".textarea__control")],lt.prototype,"input",2);f([st(".textarea__size-adjuster")],lt.prototype,"sizeAdjuster",2);f([_t()],lt.prototype,"hasFocus",2);f([C()],lt.prototype,"title",2);f([C()],lt.prototype,"name",2);f([C()],lt.prototype,"value",2);f([C({reflect:!0})],lt.prototype,"size",2);f([C({type:Boolean,reflect:!0})],lt.prototype,"filled",2);f([C()],lt.prototype,"label",2);f([C({attribute:"help-text"})],lt.prototype,"helpText",2);f([C()],lt.prototype,"placeholder",2);f([C({type:Number})],lt.prototype,"rows",2);f([C()],lt.prototype,"resize",2);f([C({type:Boolean,reflect:!0})],lt.prototype,"disabled",2);f([C({type:Boolean,reflect:!0})],lt.prototype,"readonly",2);f([C({reflect:!0})],lt.prototype,"form",2);f([C({type:Boolean,reflect:!0})],lt.prototype,"required",2);f([C({type:Number})],lt.prototype,"minlength",2);f([C({type:Number})],lt.prototype,"maxlength",2);f([C()],lt.prototype,"autocapitalize",2);f([C()],lt.prototype,"autocorrect",2);f([C()],lt.prototype,"autocomplete",2);f([C({type:Boolean})],lt.prototype,"autofocus",2);f([C()],lt.prototype,"enterkeyhint",2);f([C({type:Boolean,converter:{fromAttribute:t=>!(!t||t==="false"),toAttribute:t=>t?"true":"false"}})],lt.prototype,"spellcheck",2);f([C()],lt.prototype,"inputmode",2);f([Li()],lt.prototype,"defaultValue",2);f([ht("disabled",{waitUntilFirstUpdate:!0})],lt.prototype,"handleDisabledChange",1);f([ht("rows",{waitUntilFirstUpdate:!0})],lt.prototype,"handleRowsChange",1);f([ht("value",{waitUntilFirstUpdate:!0})],lt.prototype,"handleValueChange",1);lt.define("sl-textarea");var Ac=ct`
+  :host {
+    --max-width: 20rem;
+    --hide-delay: 0ms;
+    --show-delay: 150ms;
+
+    display: contents;
+  }
+
+  .tooltip {
+    --arrow-size: var(--sl-tooltip-arrow-size);
+    --arrow-color: var(--sl-tooltip-background-color);
+  }
+
+  .tooltip::part(popup) {
+    z-index: var(--sl-z-index-tooltip);
+  }
+
+  .tooltip[placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .tooltip[placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .tooltip[placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .tooltip[placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .tooltip__body {
+    display: block;
+    width: max-content;
+    max-width: var(--max-width);
+    border-radius: var(--sl-tooltip-border-radius);
+    background-color: var(--sl-tooltip-background-color);
+    font-family: var(--sl-tooltip-font-family);
+    font-size: var(--sl-tooltip-font-size);
+    font-weight: var(--sl-tooltip-font-weight);
+    line-height: var(--sl-tooltip-line-height);
+    text-align: start;
+    white-space: normal;
+    color: var(--sl-tooltip-color);
+    padding: var(--sl-tooltip-padding);
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+`,Sc=ct`
+  :host {
+    --arrow-color: var(--sl-color-neutral-1000);
+    --arrow-size: 6px;
+
+    /*
+     * These properties are computed to account for the arrow's dimensions after being rotated 45º. The constant
+     * 0.7071 is derived from sin(45), which is the diagonal size of the arrow's container after rotating.
+     */
+    --arrow-size-diagonal: calc(var(--arrow-size) * 0.7071);
+    --arrow-padding-offset: calc(var(--arrow-size-diagonal) - var(--arrow-size));
+
+    display: contents;
+  }
+
+  .popup {
+    position: absolute;
+    isolation: isolate;
+    max-width: var(--auto-size-available-width, none);
+    max-height: var(--auto-size-available-height, none);
+  }
+
+  .popup--fixed {
+    position: fixed;
+  }
+
+  .popup:not(.popup--active) {
+    display: none;
+  }
+
+  .popup__arrow {
+    position: absolute;
+    width: calc(var(--arrow-size-diagonal) * 2);
+    height: calc(var(--arrow-size-diagonal) * 2);
+    rotate: 45deg;
+    background: var(--arrow-color);
+    z-index: -1;
+  }
+
+  /* Hover bridge */
+  .popup-hover-bridge:not(.popup-hover-bridge--visible) {
+    display: none;
+  }
+
+  .popup-hover-bridge {
+    position: fixed;
+    z-index: calc(var(--sl-z-index-dropdown) - 1);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    clip-path: polygon(
+      var(--hover-bridge-top-left-x, 0) var(--hover-bridge-top-left-y, 0),
+      var(--hover-bridge-top-right-x, 0) var(--hover-bridge-top-right-y, 0),
+      var(--hover-bridge-bottom-right-x, 0) var(--hover-bridge-bottom-right-y, 0),
+      var(--hover-bridge-bottom-left-x, 0) var(--hover-bridge-bottom-left-y, 0)
+    );
+  }
+`;const Fe=Math.min,Qt=Math.max,so=Math.round,Yn=Math.floor,be=t=>({x:t,y:t}),Ec={left:"right",right:"left",bottom:"top",top:"bottom"},Tc={start:"end",end:"start"};function $i(t,r,o){return Qt(t,Fe(r,o))}function Pr(t,r){return typeof t=="function"?t(r):t}function Ve(t){return t.split("-")[0]}function zr(t){return t.split("-")[1]}function Pa(t){return t==="x"?"y":"x"}function Vi(t){return t==="y"?"height":"width"}const Oc=new Set(["top","bottom"]);function $e(t){return Oc.has(Ve(t))?"y":"x"}function Ni(t){return Pa($e(t))}function Pc(t,r,o){o===void 0&&(o=!1);const i=zr(t),l=Ni(t),c=Vi(l);let h=l==="x"?i===(o?"end":"start")?"right":"left":i==="start"?"bottom":"top";return r.reference[c]>r.floating[c]&&(h=ao(h)),[h,ao(h)]}function zc(t){const r=ao(t);return[Ai(t),r,Ai(r)]}function Ai(t){return t.replace(/start|end/g,r=>Tc[r])}const ra=["left","right"],na=["right","left"],Mc=["top","bottom"],Dc=["bottom","top"];function Rc(t,r,o){switch(t){case"top":case"bottom":return o?r?na:ra:r?ra:na;case"left":case"right":return r?Mc:Dc;default:return[]}}function Bc(t,r,o,i){const l=zr(t);let c=Rc(Ve(t),o==="start",i);return l&&(c=c.map(h=>h+"-"+l),r&&(c=c.concat(c.map(Ai)))),c}function ao(t){return t.replace(/left|right|bottom|top/g,r=>Ec[r])}function Ic(t){return{top:0,right:0,bottom:0,left:0,...t}}function za(t){return typeof t!="number"?Ic(t):{top:t,right:t,bottom:t,left:t}}function lo(t){const{x:r,y:o,width:i,height:l}=t;return{width:i,height:l,top:o,left:r,right:r+i,bottom:o+l,x:r,y:o}}function oa(t,r,o){let{reference:i,floating:l}=t;const c=$e(r),h=Ni(r),m=Vi(h),k=Ve(r),O=c==="y",D=i.x+i.width/2-l.width/2,P=i.y+i.height/2-l.height/2,F=i[m]/2-l[m]/2;let R;switch(k){case"top":R={x:D,y:i.y-l.height};break;case"bottom":R={x:D,y:i.y+i.height};break;case"right":R={x:i.x+i.width,y:P};break;case"left":R={x:i.x-l.width,y:P};break;default:R={x:i.x,y:i.y}}switch(zr(r)){case"start":R[h]-=F*(o&&O?-1:1);break;case"end":R[h]+=F*(o&&O?-1:1);break}return R}const Lc=async(t,r,o)=>{const{placement:i="bottom",strategy:l="absolute",middleware:c=[],platform:h}=o,m=c.filter(Boolean),k=await(h.isRTL==null?void 0:h.isRTL(r));let O=await h.getElementRects({reference:t,floating:r,strategy:l}),{x:D,y:P}=oa(O,i,k),F=i,R={},N=0;for(let W=0;W<m.length;W++){const{name:tt,fn:J}=m[W],{x:ot,y:dt,data:yt,reset:vt}=await J({x:D,y:P,initialPlacement:i,placement:F,strategy:l,middlewareData:R,rects:O,platform:h,elements:{reference:t,floating:r}});D=ot??D,P=dt??P,R={...R,[tt]:{...R[tt],...yt}},vt&&N<=50&&(N++,typeof vt=="object"&&(vt.placement&&(F=vt.placement),vt.rects&&(O=vt.rects===!0?await h.getElementRects({reference:t,floating:r,strategy:l}):vt.rects),{x:D,y:P}=oa(O,F,k)),W=-1)}return{x:D,y:P,placement:F,strategy:l,middlewareData:R}};async function qi(t,r){var o;r===void 0&&(r={});const{x:i,y:l,platform:c,rects:h,elements:m,strategy:k}=t,{boundary:O="clippingAncestors",rootBoundary:D="viewport",elementContext:P="floating",altBoundary:F=!1,padding:R=0}=Pr(r,t),N=za(R),tt=m[F?P==="floating"?"reference":"floating":P],J=lo(await c.getClippingRect({element:(o=await(c.isElement==null?void 0:c.isElement(tt)))==null||o?tt:tt.contextElement||await(c.getDocumentElement==null?void 0:c.getDocumentElement(m.floating)),boundary:O,rootBoundary:D,strategy:k})),ot=P==="floating"?{x:i,y:l,width:h.floating.width,height:h.floating.height}:h.reference,dt=await(c.getOffsetParent==null?void 0:c.getOffsetParent(m.floating)),yt=await(c.isElement==null?void 0:c.isElement(dt))?await(c.getScale==null?void 0:c.getScale(dt))||{x:1,y:1}:{x:1,y:1},vt=lo(c.convertOffsetParentRelativeRectToViewportRelativeRect?await c.convertOffsetParentRelativeRectToViewportRelativeRect({elements:m,rect:ot,offsetParent:dt,strategy:k}):ot);return{top:(J.top-vt.top+N.top)/yt.y,bottom:(vt.bottom-J.bottom+N.bottom)/yt.y,left:(J.left-vt.left+N.left)/yt.x,right:(vt.right-J.right+N.right)/yt.x}}const Fc=t=>({name:"arrow",options:t,async fn(r){const{x:o,y:i,placement:l,rects:c,platform:h,elements:m,middlewareData:k}=r,{element:O,padding:D=0}=Pr(t,r)||{};if(O==null)return{};const P=za(D),F={x:o,y:i},R=Ni(l),N=Vi(R),W=await h.getDimensions(O),tt=R==="y",J=tt?"top":"left",ot=tt?"bottom":"right",dt=tt?"clientHeight":"clientWidth",yt=c.reference[N]+c.reference[R]-F[R]-c.floating[N],vt=F[R]-c.reference[R],Ct=await(h.getOffsetParent==null?void 0:h.getOffsetParent(O));let ut=Ct?Ct[dt]:0;(!ut||!await(h.isElement==null?void 0:h.isElement(Ct)))&&(ut=m.floating[dt]||c.floating[N]);const te=yt/2-vt/2,ee=ut/2-W[N]/2-1,jt=Fe(P[J],ee),oe=Fe(P[ot],ee),Bt=jt,It=ut-W[N]-oe,zt=ut/2-W[N]/2+te,ie=$i(Bt,zt,It),Wt=!k.arrow&&zr(l)!=null&&zt!==ie&&c.reference[N]/2-(zt<Bt?jt:oe)-W[N]/2<0,Gt=Wt?zt<Bt?zt-Bt:zt-It:0;return{[R]:F[R]+Gt,data:{[R]:ie,centerOffset:zt-ie-Gt,...Wt&&{alignmentOffset:Gt}},reset:Wt}}}),Vc=function(t){return t===void 0&&(t={}),{name:"flip",options:t,async fn(r){var o,i;const{placement:l,middlewareData:c,rects:h,initialPlacement:m,platform:k,elements:O}=r,{mainAxis:D=!0,crossAxis:P=!0,fallbackPlacements:F,fallbackStrategy:R="bestFit",fallbackAxisSideDirection:N="none",flipAlignment:W=!0,...tt}=Pr(t,r);if((o=c.arrow)!=null&&o.alignmentOffset)return{};const J=Ve(l),ot=$e(m),dt=Ve(m)===m,yt=await(k.isRTL==null?void 0:k.isRTL(O.floating)),vt=F||(dt||!W?[ao(m)]:zc(m)),Ct=N!=="none";!F&&Ct&&vt.push(...Bc(m,W,N,yt));const ut=[m,...vt],te=await qi(r,tt),ee=[];let jt=((i=c.flip)==null?void 0:i.overflows)||[];if(D&&ee.push(te[J]),P){const zt=Pc(l,h,yt);ee.push(te[zt[0]],te[zt[1]])}if(jt=[...jt,{placement:l,overflows:ee}],!ee.every(zt=>zt<=0)){var oe,Bt;const zt=(((oe=c.flip)==null?void 0:oe.index)||0)+1,ie=ut[zt];if(ie&&(!(P==="alignment"?ot!==$e(ie):!1)||jt.every(Et=>$e(Et.placement)===ot?Et.overflows[0]>0:!0)))return{data:{index:zt,overflows:jt},reset:{placement:ie}};let Wt=(Bt=jt.filter(Gt=>Gt.overflows[0]<=0).sort((Gt,Et)=>Gt.overflows[1]-Et.overflows[1])[0])==null?void 0:Bt.placement;if(!Wt)switch(R){case"bestFit":{var It;const Gt=(It=jt.filter(Et=>{if(Ct){const Kt=$e(Et.placement);return Kt===ot||Kt==="y"}return!0}).map(Et=>[Et.placement,Et.overflows.filter(Kt=>Kt>0).reduce((Kt,se)=>Kt+se,0)]).sort((Et,Kt)=>Et[1]-Kt[1])[0])==null?void 0:It[0];Gt&&(Wt=Gt);break}case"initialPlacement":Wt=m;break}if(l!==Wt)return{reset:{placement:Wt}}}return{}}}},Nc=new Set(["left","top"]);async function qc(t,r){const{placement:o,platform:i,elements:l}=t,c=await(i.isRTL==null?void 0:i.isRTL(l.floating)),h=Ve(o),m=zr(o),k=$e(o)==="y",O=Nc.has(h)?-1:1,D=c&&k?-1:1,P=Pr(r,t);let{mainAxis:F,crossAxis:R,alignmentAxis:N}=typeof P=="number"?{mainAxis:P,crossAxis:0,alignmentAxis:null}:{mainAxis:P.mainAxis||0,crossAxis:P.crossAxis||0,alignmentAxis:P.alignmentAxis};return m&&typeof N=="number"&&(R=m==="end"?N*-1:N),k?{x:R*D,y:F*O}:{x:F*O,y:R*D}}const jc=function(t){return t===void 0&&(t=0),{name:"offset",options:t,async fn(r){var o,i;const{x:l,y:c,placement:h,middlewareData:m}=r,k=await qc(r,t);return h===((o=m.offset)==null?void 0:o.placement)&&(i=m.arrow)!=null&&i.alignmentOffset?{}:{x:l+k.x,y:c+k.y,data:{...k,placement:h}}}}},Kc=function(t){return t===void 0&&(t={}),{name:"shift",options:t,async fn(r){const{x:o,y:i,placement:l}=r,{mainAxis:c=!0,crossAxis:h=!1,limiter:m={fn:tt=>{let{x:J,y:ot}=tt;return{x:J,y:ot}}},...k}=Pr(t,r),O={x:o,y:i},D=await qi(r,k),P=$e(Ve(l)),F=Pa(P);let R=O[F],N=O[P];if(c){const tt=F==="y"?"top":"left",J=F==="y"?"bottom":"right",ot=R+D[tt],dt=R-D[J];R=$i(ot,R,dt)}if(h){const tt=P==="y"?"top":"left",J=P==="y"?"bottom":"right",ot=N+D[tt],dt=N-D[J];N=$i(ot,N,dt)}const W=m.fn({...r,[F]:R,[P]:N});return{...W,data:{x:W.x-o,y:W.y-i,enabled:{[F]:c,[P]:h}}}}}},Hc=function(t){return t===void 0&&(t={}),{name:"size",options:t,async fn(r){var o,i;const{placement:l,rects:c,platform:h,elements:m}=r,{apply:k=()=>{},...O}=Pr(t,r),D=await qi(r,O),P=Ve(l),F=zr(l),R=$e(l)==="y",{width:N,height:W}=c.floating;let tt,J;P==="top"||P==="bottom"?(tt=P,J=F===(await(h.isRTL==null?void 0:h.isRTL(m.floating))?"start":"end")?"left":"right"):(J=P,tt=F==="end"?"top":"bottom");const ot=W-D.top-D.bottom,dt=N-D.left-D.right,yt=Fe(W-D[tt],ot),vt=Fe(N-D[J],dt),Ct=!r.middlewareData.shift;let ut=yt,te=vt;if((o=r.middlewareData.shift)!=null&&o.enabled.x&&(te=dt),(i=r.middlewareData.shift)!=null&&i.enabled.y&&(ut=ot),Ct&&!F){const jt=Qt(D.left,0),oe=Qt(D.right,0),Bt=Qt(D.top,0),It=Qt(D.bottom,0);R?te=N-2*(jt!==0||oe!==0?jt+oe:Qt(D.left,D.right)):ut=W-2*(Bt!==0||It!==0?Bt+It:Qt(D.top,D.bottom))}await k({...r,availableWidth:te,availableHeight:ut});const ee=await h.getDimensions(m.floating);return N!==ee.width||W!==ee.height?{reset:{rects:!0}}:{}}}};function _o(){return typeof window<"u"}function Mr(t){return Ma(t)?(t.nodeName||"").toLowerCase():"#document"}function Zt(t){var r;return(t==null||(r=t.ownerDocument)==null?void 0:r.defaultView)||window}function ye(t){var r;return(r=(Ma(t)?t.ownerDocument:t.document)||window.document)==null?void 0:r.documentElement}function Ma(t){return _o()?t instanceof Node||t instanceof Zt(t).Node:!1}function le(t){return _o()?t instanceof Element||t instanceof Zt(t).Element:!1}function me(t){return _o()?t instanceof HTMLElement||t instanceof Zt(t).HTMLElement:!1}function ia(t){return!_o()||typeof ShadowRoot>"u"?!1:t instanceof ShadowRoot||t instanceof Zt(t).ShadowRoot}const Uc=new Set(["inline","contents"]);function vn(t){const{overflow:r,overflowX:o,overflowY:i,display:l}=ue(t);return/auto|scroll|overlay|hidden|clip/.test(r+i+o)&&!Uc.has(l)}const Wc=new Set(["table","td","th"]);function Gc(t){return Wc.has(Mr(t))}const Yc=[":popover-open",":modal"];function xo(t){return Yc.some(r=>{try{return t.matches(r)}catch{return!1}})}const Xc=["transform","translate","scale","rotate","perspective"],Qc=["transform","translate","scale","rotate","perspective","filter"],Zc=["paint","layout","strict","content"];function ko(t){const r=ji(),o=le(t)?ue(t):t;return Xc.some(i=>o[i]?o[i]!=="none":!1)||(o.containerType?o.containerType!=="normal":!1)||!r&&(o.backdropFilter?o.backdropFilter!=="none":!1)||!r&&(o.filter?o.filter!=="none":!1)||Qc.some(i=>(o.willChange||"").includes(i))||Zc.some(i=>(o.contain||"").includes(i))}function Jc(t){let r=Ne(t);for(;me(r)&&!$r(r);){if(ko(r))return r;if(xo(r))return null;r=Ne(r)}return null}function ji(){return typeof CSS>"u"||!CSS.supports?!1:CSS.supports("-webkit-backdrop-filter","none")}const td=new Set(["html","body","#document"]);function $r(t){return td.has(Mr(t))}function ue(t){return Zt(t).getComputedStyle(t)}function Co(t){return le(t)?{scrollLeft:t.scrollLeft,scrollTop:t.scrollTop}:{scrollLeft:t.scrollX,scrollTop:t.scrollY}}function Ne(t){if(Mr(t)==="html")return t;const r=t.assignedSlot||t.parentNode||ia(t)&&t.host||ye(t);return ia(r)?r.host:r}function Da(t){const r=Ne(t);return $r(r)?t.ownerDocument?t.ownerDocument.body:t.body:me(r)&&vn(r)?r:Da(r)}function hn(t,r,o){var i;r===void 0&&(r=[]),o===void 0&&(o=!0);const l=Da(t),c=l===((i=t.ownerDocument)==null?void 0:i.body),h=Zt(l);if(c){const m=Si(h);return r.concat(h,h.visualViewport||[],vn(l)?l:[],m&&o?hn(m):[])}return r.concat(l,hn(l,[],o))}function Si(t){return t.parent&&Object.getPrototypeOf(t.parent)?t.frameElement:null}function Ra(t){const r=ue(t);let o=parseFloat(r.width)||0,i=parseFloat(r.height)||0;const l=me(t),c=l?t.offsetWidth:o,h=l?t.offsetHeight:i,m=so(o)!==c||so(i)!==h;return m&&(o=c,i=h),{width:o,height:i,$:m}}function Ki(t){return le(t)?t:t.contextElement}function _r(t){const r=Ki(t);if(!me(r))return be(1);const o=r.getBoundingClientRect(),{width:i,height:l,$:c}=Ra(r);let h=(c?so(o.width):o.width)/i,m=(c?so(o.height):o.height)/l;return(!h||!Number.isFinite(h))&&(h=1),(!m||!Number.isFinite(m))&&(m=1),{x:h,y:m}}const ed=be(0);function Ba(t){const r=Zt(t);return!ji()||!r.visualViewport?ed:{x:r.visualViewport.offsetLeft,y:r.visualViewport.offsetTop}}function rd(t,r,o){return r===void 0&&(r=!1),!o||r&&o!==Zt(t)?!1:r}function ar(t,r,o,i){r===void 0&&(r=!1),o===void 0&&(o=!1);const l=t.getBoundingClientRect(),c=Ki(t);let h=be(1);r&&(i?le(i)&&(h=_r(i)):h=_r(t));const m=rd(c,o,i)?Ba(c):be(0);let k=(l.left+m.x)/h.x,O=(l.top+m.y)/h.y,D=l.width/h.x,P=l.height/h.y;if(c){const F=Zt(c),R=i&&le(i)?Zt(i):i;let N=F,W=Si(N);for(;W&&i&&R!==N;){const tt=_r(W),J=W.getBoundingClientRect(),ot=ue(W),dt=J.left+(W.clientLeft+parseFloat(ot.paddingLeft))*tt.x,yt=J.top+(W.clientTop+parseFloat(ot.paddingTop))*tt.y;k*=tt.x,O*=tt.y,D*=tt.x,P*=tt.y,k+=dt,O+=yt,N=Zt(W),W=Si(N)}}return lo({width:D,height:P,x:k,y:O})}function $o(t,r){const o=Co(t).scrollLeft;return r?r.left+o:ar(ye(t)).left+o}function Ia(t,r){const o=t.getBoundingClientRect(),i=o.left+r.scrollLeft-$o(t,o),l=o.top+r.scrollTop;return{x:i,y:l}}function nd(t){let{elements:r,rect:o,offsetParent:i,strategy:l}=t;const c=l==="fixed",h=ye(i),m=r?xo(r.floating):!1;if(i===h||m&&c)return o;let k={scrollLeft:0,scrollTop:0},O=be(1);const D=be(0),P=me(i);if((P||!P&&!c)&&((Mr(i)!=="body"||vn(h))&&(k=Co(i)),me(i))){const R=ar(i);O=_r(i),D.x=R.x+i.clientLeft,D.y=R.y+i.clientTop}const F=h&&!P&&!c?Ia(h,k):be(0);return{width:o.width*O.x,height:o.height*O.y,x:o.x*O.x-k.scrollLeft*O.x+D.x+F.x,y:o.y*O.y-k.scrollTop*O.y+D.y+F.y}}function od(t){return Array.from(t.getClientRects())}function id(t){const r=ye(t),o=Co(t),i=t.ownerDocument.body,l=Qt(r.scrollWidth,r.clientWidth,i.scrollWidth,i.clientWidth),c=Qt(r.scrollHeight,r.clientHeight,i.scrollHeight,i.clientHeight);let h=-o.scrollLeft+$o(t);const m=-o.scrollTop;return ue(i).direction==="rtl"&&(h+=Qt(r.clientWidth,i.clientWidth)-l),{width:l,height:c,x:h,y:m}}const sa=25;function sd(t,r){const o=Zt(t),i=ye(t),l=o.visualViewport;let c=i.clientWidth,h=i.clientHeight,m=0,k=0;if(l){c=l.width,h=l.height;const D=ji();(!D||D&&r==="fixed")&&(m=l.offsetLeft,k=l.offsetTop)}const O=$o(i);if(O<=0){const D=i.ownerDocument,P=D.body,F=getComputedStyle(P),R=D.compatMode==="CSS1Compat"&&parseFloat(F.marginLeft)+parseFloat(F.marginRight)||0,N=Math.abs(i.clientWidth-P.clientWidth-R);N<=sa&&(c-=N)}else O<=sa&&(c+=O);return{width:c,height:h,x:m,y:k}}const ad=new Set(["absolute","fixed"]);function ld(t,r){const o=ar(t,!0,r==="fixed"),i=o.top+t.clientTop,l=o.left+t.clientLeft,c=me(t)?_r(t):be(1),h=t.clientWidth*c.x,m=t.clientHeight*c.y,k=l*c.x,O=i*c.y;return{width:h,height:m,x:k,y:O}}function aa(t,r,o){let i;if(r==="viewport")i=sd(t,o);else if(r==="document")i=id(ye(t));else if(le(r))i=ld(r,o);else{const l=Ba(t);i={x:r.x-l.x,y:r.y-l.y,width:r.width,height:r.height}}return lo(i)}function La(t,r){const o=Ne(t);return o===r||!le(o)||$r(o)?!1:ue(o).position==="fixed"||La(o,r)}function ud(t,r){const o=r.get(t);if(o)return o;let i=hn(t,[],!1).filter(m=>le(m)&&Mr(m)!=="body"),l=null;const c=ue(t).position==="fixed";let h=c?Ne(t):t;for(;le(h)&&!$r(h);){const m=ue(h),k=ko(h);!k&&m.position==="fixed"&&(l=null),(c?!k&&!l:!k&&m.position==="static"&&!!l&&ad.has(l.position)||vn(h)&&!k&&La(t,h))?i=i.filter(D=>D!==h):l=m,h=Ne(h)}return r.set(t,i),i}function cd(t){let{element:r,boundary:o,rootBoundary:i,strategy:l}=t;const h=[...o==="clippingAncestors"?xo(r)?[]:ud(r,this._c):[].concat(o),i],m=h[0],k=h.reduce((O,D)=>{const P=aa(r,D,l);return O.top=Qt(P.top,O.top),O.right=Fe(P.right,O.right),O.bottom=Fe(P.bottom,O.bottom),O.left=Qt(P.left,O.left),O},aa(r,m,l));return{width:k.right-k.left,height:k.bottom-k.top,x:k.left,y:k.top}}function dd(t){const{width:r,height:o}=Ra(t);return{width:r,height:o}}function hd(t,r,o){const i=me(r),l=ye(r),c=o==="fixed",h=ar(t,!0,c,r);let m={scrollLeft:0,scrollTop:0};const k=be(0);function O(){k.x=$o(l)}if(i||!i&&!c)if((Mr(r)!=="body"||vn(l))&&(m=Co(r)),i){const R=ar(r,!0,c,r);k.x=R.x+r.clientLeft,k.y=R.y+r.clientTop}else l&&O();c&&!i&&l&&O();const D=l&&!i&&!c?Ia(l,m):be(0),P=h.left+m.scrollLeft-k.x-D.x,F=h.top+m.scrollTop-k.y-D.y;return{x:P,y:F,width:h.width,height:h.height}}function vi(t){return ue(t).position==="static"}function la(t,r){if(!me(t)||ue(t).position==="fixed")return null;if(r)return r(t);let o=t.offsetParent;return ye(t)===o&&(o=o.ownerDocument.body),o}function Fa(t,r){const o=Zt(t);if(xo(t))return o;if(!me(t)){let l=Ne(t);for(;l&&!$r(l);){if(le(l)&&!vi(l))return l;l=Ne(l)}return o}let i=la(t,r);for(;i&&Gc(i)&&vi(i);)i=la(i,r);return i&&$r(i)&&vi(i)&&!ko(i)?o:i||Jc(t)||o}const pd=async function(t){const r=this.getOffsetParent||Fa,o=this.getDimensions,i=await o(t.floating);return{reference:hd(t.reference,await r(t.floating),t.strategy),floating:{x:0,y:0,width:i.width,height:i.height}}};function fd(t){return ue(t).direction==="rtl"}const Zn={convertOffsetParentRelativeRectToViewportRelativeRect:nd,getDocumentElement:ye,getClippingRect:cd,getOffsetParent:Fa,getElementRects:pd,getClientRects:od,getDimensions:dd,getScale:_r,isElement:le,isRTL:fd};function Va(t,r){return t.x===r.x&&t.y===r.y&&t.width===r.width&&t.height===r.height}function bd(t,r){let o=null,i;const l=ye(t);function c(){var m;clearTimeout(i),(m=o)==null||m.disconnect(),o=null}function h(m,k){m===void 0&&(m=!1),k===void 0&&(k=1),c();const O=t.getBoundingClientRect(),{left:D,top:P,width:F,height:R}=O;if(m||r(),!F||!R)return;const N=Yn(P),W=Yn(l.clientWidth-(D+F)),tt=Yn(l.clientHeight-(P+R)),J=Yn(D),dt={rootMargin:-N+"px "+-W+"px "+-tt+"px "+-J+"px",threshold:Qt(0,Fe(1,k))||1};let yt=!0;function vt(Ct){const ut=Ct[0].intersectionRatio;if(ut!==k){if(!yt)return h();ut?h(!1,ut):i=setTimeout(()=>{h(!1,1e-7)},1e3)}ut===1&&!Va(O,t.getBoundingClientRect())&&h(),yt=!1}try{o=new IntersectionObserver(vt,{...dt,root:l.ownerDocument})}catch{o=new IntersectionObserver(vt,dt)}o.observe(t)}return h(!0),c}function md(t,r,o,i){i===void 0&&(i={});const{ancestorScroll:l=!0,ancestorResize:c=!0,elementResize:h=typeof ResizeObserver=="function",layoutShift:m=typeof IntersectionObserver=="function",animationFrame:k=!1}=i,O=Ki(t),D=l||c?[...O?hn(O):[],...hn(r)]:[];D.forEach(J=>{l&&J.addEventListener("scroll",o,{passive:!0}),c&&J.addEventListener("resize",o)});const P=O&&m?bd(O,o):null;let F=-1,R=null;h&&(R=new ResizeObserver(J=>{let[ot]=J;ot&&ot.target===O&&R&&(R.unobserve(r),cancelAnimationFrame(F),F=requestAnimationFrame(()=>{var dt;(dt=R)==null||dt.observe(r)})),o()}),O&&!k&&R.observe(O),R.observe(r));let N,W=k?ar(t):null;k&&tt();function tt(){const J=ar(t);W&&!Va(W,J)&&o(),W=J,N=requestAnimationFrame(tt)}return o(),()=>{var J;D.forEach(ot=>{l&&ot.removeEventListener("scroll",o),c&&ot.removeEventListener("resize",o)}),P?.(),(J=R)==null||J.disconnect(),R=null,k&&cancelAnimationFrame(N)}}const vd=jc,gd=Kc,yd=Vc,ua=Hc,wd=Fc,_d=(t,r,o)=>{const i=new Map,l={platform:Zn,...o},c={...l.platform,_c:i};return Lc(t,r,{...l,platform:c})};function xd(t){return kd(t)}function gi(t){return t.assignedSlot?t.assignedSlot:t.parentNode instanceof ShadowRoot?t.parentNode.host:t.parentNode}function kd(t){for(let r=t;r;r=gi(r))if(r instanceof Element&&getComputedStyle(r).display==="none")return null;for(let r=gi(t);r;r=gi(r)){if(!(r instanceof Element))continue;const o=getComputedStyle(r);if(o.display!=="contents"&&(o.position!=="static"||ko(o)||r.tagName==="BODY"))return r}return null}function Cd(t){return t!==null&&typeof t=="object"&&"getBoundingClientRect"in t&&("contextElement"in t?t.contextElement instanceof Element:!0)}var bt=class extends gt{constructor(){super(...arguments),this.localize=new ve(this),this.active=!1,this.placement="top",this.strategy="absolute",this.distance=0,this.skidding=0,this.arrow=!1,this.arrowPlacement="anchor",this.arrowPadding=10,this.flip=!1,this.flipFallbackPlacements="",this.flipFallbackStrategy="best-fit",this.flipPadding=0,this.shift=!1,this.shiftPadding=0,this.autoSizePadding=0,this.hoverBridge=!1,this.updateHoverBridge=()=>{if(this.hoverBridge&&this.anchorEl){const t=this.anchorEl.getBoundingClientRect(),r=this.popup.getBoundingClientRect(),o=this.placement.includes("top")||this.placement.includes("bottom");let i=0,l=0,c=0,h=0,m=0,k=0,O=0,D=0;o?t.top<r.top?(i=t.left,l=t.bottom,c=t.right,h=t.bottom,m=r.left,k=r.top,O=r.right,D=r.top):(i=r.left,l=r.bottom,c=r.right,h=r.bottom,m=t.left,k=t.top,O=t.right,D=t.top):t.left<r.left?(i=t.right,l=t.top,c=r.left,h=r.top,m=t.right,k=t.bottom,O=r.left,D=r.bottom):(i=r.right,l=r.top,c=t.left,h=t.top,m=r.right,k=r.bottom,O=t.left,D=t.bottom),this.style.setProperty("--hover-bridge-top-left-x",`${i}px`),this.style.setProperty("--hover-bridge-top-left-y",`${l}px`),this.style.setProperty("--hover-bridge-top-right-x",`${c}px`),this.style.setProperty("--hover-bridge-top-right-y",`${h}px`),this.style.setProperty("--hover-bridge-bottom-left-x",`${m}px`),this.style.setProperty("--hover-bridge-bottom-left-y",`${k}px`),this.style.setProperty("--hover-bridge-bottom-right-x",`${O}px`),this.style.setProperty("--hover-bridge-bottom-right-y",`${D}px`)}}}async connectedCallback(){super.connectedCallback(),await this.updateComplete,this.start()}disconnectedCallback(){super.disconnectedCallback(),this.stop()}async updated(t){super.updated(t),t.has("active")&&(this.active?this.start():this.stop()),t.has("anchor")&&this.handleAnchorChange(),this.active&&(await this.updateComplete,this.reposition())}async handleAnchorChange(){if(await this.stop(),this.anchor&&typeof this.anchor=="string"){const t=this.getRootNode();this.anchorEl=t.getElementById(this.anchor)}else this.anchor instanceof Element||Cd(this.anchor)?this.anchorEl=this.anchor:this.anchorEl=this.querySelector('[slot="anchor"]');this.anchorEl instanceof HTMLSlotElement&&(this.anchorEl=this.anchorEl.assignedElements({flatten:!0})[0]),this.anchorEl&&this.active&&this.start()}start(){!this.anchorEl||!this.active||(this.cleanup=md(this.anchorEl,this.popup,()=>{this.reposition()}))}async stop(){return new Promise(t=>{this.cleanup?(this.cleanup(),this.cleanup=void 0,this.removeAttribute("data-current-placement"),this.style.removeProperty("--auto-size-available-width"),this.style.removeProperty("--auto-size-available-height"),requestAnimationFrame(()=>t())):t()})}reposition(){if(!this.active||!this.anchorEl)return;const t=[vd({mainAxis:this.distance,crossAxis:this.skidding})];this.sync?t.push(ua({apply:({rects:o})=>{const i=this.sync==="width"||this.sync==="both",l=this.sync==="height"||this.sync==="both";this.popup.style.width=i?`${o.reference.width}px`:"",this.popup.style.height=l?`${o.reference.height}px`:""}})):(this.popup.style.width="",this.popup.style.height=""),this.flip&&t.push(yd({boundary:this.flipBoundary,fallbackPlacements:this.flipFallbackPlacements,fallbackStrategy:this.flipFallbackStrategy==="best-fit"?"bestFit":"initialPlacement",padding:this.flipPadding})),this.shift&&t.push(gd({boundary:this.shiftBoundary,padding:this.shiftPadding})),this.autoSize?t.push(ua({boundary:this.autoSizeBoundary,padding:this.autoSizePadding,apply:({availableWidth:o,availableHeight:i})=>{this.autoSize==="vertical"||this.autoSize==="both"?this.style.setProperty("--auto-size-available-height",`${i}px`):this.style.removeProperty("--auto-size-available-height"),this.autoSize==="horizontal"||this.autoSize==="both"?this.style.setProperty("--auto-size-available-width",`${o}px`):this.style.removeProperty("--auto-size-available-width")}})):(this.style.removeProperty("--auto-size-available-width"),this.style.removeProperty("--auto-size-available-height")),this.arrow&&t.push(wd({element:this.arrowEl,padding:this.arrowPadding}));const r=this.strategy==="absolute"?o=>Zn.getOffsetParent(o,xd):Zn.getOffsetParent;_d(this.anchorEl,this.popup,{placement:this.placement,middleware:t,strategy:this.strategy,platform:fo(je({},Zn),{getOffsetParent:r})}).then(({x:o,y:i,middlewareData:l,placement:c})=>{const h=this.localize.dir()==="rtl",m={top:"bottom",right:"left",bottom:"top",left:"right"}[c.split("-")[0]];if(this.setAttribute("data-current-placement",c),Object.assign(this.popup.style,{left:`${o}px`,top:`${i}px`}),this.arrow){const k=l.arrow.x,O=l.arrow.y;let D="",P="",F="",R="";if(this.arrowPlacement==="start"){const N=typeof k=="number"?`calc(${this.arrowPadding}px - var(--arrow-padding-offset))`:"";D=typeof O=="number"?`calc(${this.arrowPadding}px - var(--arrow-padding-offset))`:"",P=h?N:"",R=h?"":N}else if(this.arrowPlacement==="end"){const N=typeof k=="number"?`calc(${this.arrowPadding}px - var(--arrow-padding-offset))`:"";P=h?"":N,R=h?N:"",F=typeof O=="number"?`calc(${this.arrowPadding}px - var(--arrow-padding-offset))`:""}else this.arrowPlacement==="center"?(R=typeof k=="number"?"calc(50% - var(--arrow-size-diagonal))":"",D=typeof O=="number"?"calc(50% - var(--arrow-size-diagonal))":""):(R=typeof k=="number"?`${k}px`:"",D=typeof O=="number"?`${O}px`:"");Object.assign(this.arrowEl.style,{top:D,right:P,bottom:F,left:R,[m]:"calc(var(--arrow-size-diagonal) * -1)"})}}),requestAnimationFrame(()=>this.updateHoverBridge()),this.emit("sl-reposition")}render(){return X`
+      <slot name="anchor" @slotchange=${this.handleAnchorChange}></slot>
+
+      <span
+        part="hover-bridge"
+        class=${kt({"popup-hover-bridge":!0,"popup-hover-bridge--visible":this.hoverBridge&&this.active})}
+      ></span>
+
+      <div
+        part="popup"
+        class=${kt({popup:!0,"popup--active":this.active,"popup--fixed":this.strategy==="fixed","popup--has-arrow":this.arrow})}
+      >
+        <slot></slot>
+        ${this.arrow?X`<div part="arrow" class="popup__arrow" role="presentation"></div>`:""}
+      </div>
+    `}};bt.styles=[St,Sc];f([st(".popup")],bt.prototype,"popup",2);f([st(".popup__arrow")],bt.prototype,"arrowEl",2);f([C()],bt.prototype,"anchor",2);f([C({type:Boolean,reflect:!0})],bt.prototype,"active",2);f([C({reflect:!0})],bt.prototype,"placement",2);f([C({reflect:!0})],bt.prototype,"strategy",2);f([C({type:Number})],bt.prototype,"distance",2);f([C({type:Number})],bt.prototype,"skidding",2);f([C({type:Boolean})],bt.prototype,"arrow",2);f([C({attribute:"arrow-placement"})],bt.prototype,"arrowPlacement",2);f([C({attribute:"arrow-padding",type:Number})],bt.prototype,"arrowPadding",2);f([C({type:Boolean})],bt.prototype,"flip",2);f([C({attribute:"flip-fallback-placements",converter:{fromAttribute:t=>t.split(" ").map(r=>r.trim()).filter(r=>r!==""),toAttribute:t=>t.join(" ")}})],bt.prototype,"flipFallbackPlacements",2);f([C({attribute:"flip-fallback-strategy"})],bt.prototype,"flipFallbackStrategy",2);f([C({type:Object})],bt.prototype,"flipBoundary",2);f([C({attribute:"flip-padding",type:Number})],bt.prototype,"flipPadding",2);f([C({type:Boolean})],bt.prototype,"shift",2);f([C({type:Object})],bt.prototype,"shiftBoundary",2);f([C({attribute:"shift-padding",type:Number})],bt.prototype,"shiftPadding",2);f([C({attribute:"auto-size"})],bt.prototype,"autoSize",2);f([C()],bt.prototype,"sync",2);f([C({type:Object})],bt.prototype,"autoSizeBoundary",2);f([C({attribute:"auto-size-padding",type:Number})],bt.prototype,"autoSizePadding",2);f([C({attribute:"hover-bridge",type:Boolean})],bt.prototype,"hoverBridge",2);var Rt=class extends gt{constructor(){super(),this.localize=new ve(this),this.content="",this.placement="top",this.disabled=!1,this.distance=8,this.open=!1,this.skidding=0,this.trigger="hover focus",this.hoist=!1,this.handleBlur=()=>{this.hasTrigger("focus")&&this.hide()},this.handleClick=()=>{this.hasTrigger("click")&&(this.open?this.hide():this.show())},this.handleFocus=()=>{this.hasTrigger("focus")&&this.show()},this.handleDocumentKeyDown=t=>{t.key==="Escape"&&(t.stopPropagation(),this.hide())},this.handleMouseOver=()=>{if(this.hasTrigger("hover")){const t=ta(getComputedStyle(this).getPropertyValue("--show-delay"));clearTimeout(this.hoverTimeout),this.hoverTimeout=window.setTimeout(()=>this.show(),t)}},this.handleMouseOut=()=>{if(this.hasTrigger("hover")){const t=ta(getComputedStyle(this).getPropertyValue("--hide-delay"));clearTimeout(this.hoverTimeout),this.hoverTimeout=window.setTimeout(()=>this.hide(),t)}},this.addEventListener("blur",this.handleBlur,!0),this.addEventListener("focus",this.handleFocus,!0),this.addEventListener("click",this.handleClick),this.addEventListener("mouseover",this.handleMouseOver),this.addEventListener("mouseout",this.handleMouseOut)}disconnectedCallback(){var t;super.disconnectedCallback(),(t=this.closeWatcher)==null||t.destroy(),document.removeEventListener("keydown",this.handleDocumentKeyDown)}firstUpdated(){this.body.hidden=!this.open,this.open&&(this.popup.active=!0,this.popup.reposition())}hasTrigger(t){return this.trigger.split(" ").includes(t)}async handleOpenChange(){var t,r;if(this.open){if(this.disabled)return;this.emit("sl-show"),"CloseWatcher"in window?((t=this.closeWatcher)==null||t.destroy(),this.closeWatcher=new CloseWatcher,this.closeWatcher.onclose=()=>{this.hide()}):document.addEventListener("keydown",this.handleDocumentKeyDown),await Be(this.body),this.body.hidden=!1,this.popup.active=!0;const{keyframes:o,options:i}=ke(this,"tooltip.show",{dir:this.localize.dir()});await Ce(this.popup.popup,o,i),this.popup.reposition(),this.emit("sl-after-show")}else{this.emit("sl-hide"),(r=this.closeWatcher)==null||r.destroy(),document.removeEventListener("keydown",this.handleDocumentKeyDown),await Be(this.body);const{keyframes:o,options:i}=ke(this,"tooltip.hide",{dir:this.localize.dir()});await Ce(this.popup.popup,o,i),this.popup.active=!1,this.body.hidden=!0,this.emit("sl-after-hide")}}async handleOptionsChange(){this.hasUpdated&&(await this.updateComplete,this.popup.reposition())}handleDisabledChange(){this.disabled&&this.open&&this.hide()}async show(){if(!this.open)return this.open=!0,Cr(this,"sl-after-show")}async hide(){if(this.open)return this.open=!1,Cr(this,"sl-after-hide")}render(){return X`
+      <sl-popup
+        part="base"
+        exportparts="
+          popup:base__popup,
+          arrow:base__arrow
+        "
+        class=${kt({tooltip:!0,"tooltip--open":this.open})}
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist?"fixed":"absolute"}
+        flip
+        shift
+        arrow
+        hover-bridge
+      >
+        ${""}
+        <slot slot="anchor" aria-describedby="tooltip"></slot>
+
+        ${""}
+        <div part="body" id="tooltip" class="tooltip__body" role="tooltip" aria-live=${this.open?"polite":"off"}>
+          <slot name="content">${this.content}</slot>
+        </div>
+      </sl-popup>
+    `}};Rt.styles=[St,Ac];Rt.dependencies={"sl-popup":bt};f([st("slot:not([name])")],Rt.prototype,"defaultSlot",2);f([st(".tooltip__body")],Rt.prototype,"body",2);f([st("sl-popup")],Rt.prototype,"popup",2);f([C()],Rt.prototype,"content",2);f([C()],Rt.prototype,"placement",2);f([C({type:Boolean,reflect:!0})],Rt.prototype,"disabled",2);f([C({type:Number})],Rt.prototype,"distance",2);f([C({type:Boolean,reflect:!0})],Rt.prototype,"open",2);f([C({type:Number})],Rt.prototype,"skidding",2);f([C()],Rt.prototype,"trigger",2);f([C({type:Boolean})],Rt.prototype,"hoist",2);f([ht("open",{waitUntilFirstUpdate:!0})],Rt.prototype,"handleOpenChange",1);f([ht(["content","distance","hoist","placement","skidding"])],Rt.prototype,"handleOptionsChange",1);f([ht("disabled")],Rt.prototype,"handleDisabledChange",1);Se("tooltip.show",{keyframes:[{opacity:0,scale:.8},{opacity:1,scale:1}],options:{duration:150,easing:"ease"}});Se("tooltip.hide",{keyframes:[{opacity:1,scale:1},{opacity:0,scale:.8}],options:{duration:150,easing:"ease"}});Rt.define("sl-tooltip");var $d=ct`
+  :host {
+    display: inline-block;
+  }
+
+  .dropdown::part(popup) {
+    z-index: var(--sl-z-index-dropdown);
+  }
+
+  .dropdown[data-current-placement^='top']::part(popup) {
+    transform-origin: bottom;
+  }
+
+  .dropdown[data-current-placement^='bottom']::part(popup) {
+    transform-origin: top;
+  }
+
+  .dropdown[data-current-placement^='left']::part(popup) {
+    transform-origin: right;
+  }
+
+  .dropdown[data-current-placement^='right']::part(popup) {
+    transform-origin: left;
+  }
+
+  .dropdown__trigger {
+    display: block;
+  }
+
+  .dropdown__panel {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    box-shadow: var(--sl-shadow-large);
+    border-radius: var(--sl-border-radius-medium);
+    pointer-events: none;
+  }
+
+  .dropdown--open .dropdown__panel {
+    display: block;
+    pointer-events: all;
+  }
+
+  /* When users slot a menu, make sure it conforms to the popup's auto-size */
+  ::slotted(sl-menu) {
+    max-width: var(--auto-size-available-width) !important;
+    max-height: var(--auto-size-available-height) !important;
+  }
+`,qt=class extends gt{constructor(){super(...arguments),this.localize=new ve(this),this.open=!1,this.placement="bottom-start",this.disabled=!1,this.stayOpenOnSelect=!1,this.distance=0,this.skidding=0,this.hoist=!1,this.sync=void 0,this.handleKeyDown=t=>{this.open&&t.key==="Escape"&&(t.stopPropagation(),this.hide(),this.focusOnTrigger())},this.handleDocumentKeyDown=t=>{var r;if(t.key==="Escape"&&this.open&&!this.closeWatcher){t.stopPropagation(),this.focusOnTrigger(),this.hide();return}if(t.key==="Tab"){if(this.open&&((r=document.activeElement)==null?void 0:r.tagName.toLowerCase())==="sl-menu-item"){t.preventDefault(),this.hide(),this.focusOnTrigger();return}const o=(i,l)=>{if(!i)return null;const c=i.closest(l);if(c)return c;const h=i.getRootNode();return h instanceof ShadowRoot?o(h.host,l):null};setTimeout(()=>{var i;const l=((i=this.containingElement)==null?void 0:i.getRootNode())instanceof ShadowRoot?Ea():document.activeElement;(!this.containingElement||o(l,this.containingElement.tagName.toLowerCase())!==this.containingElement)&&this.hide()})}},this.handleDocumentMouseDown=t=>{const r=t.composedPath();this.containingElement&&!r.includes(this.containingElement)&&this.hide()},this.handlePanelSelect=t=>{const r=t.target;!this.stayOpenOnSelect&&r.tagName.toLowerCase()==="sl-menu"&&(this.hide(),this.focusOnTrigger())}}connectedCallback(){super.connectedCallback(),this.containingElement||(this.containingElement=this)}firstUpdated(){this.panel.hidden=!this.open,this.open&&(this.addOpenListeners(),this.popup.active=!0)}disconnectedCallback(){super.disconnectedCallback(),this.removeOpenListeners(),this.hide()}focusOnTrigger(){const t=this.trigger.assignedElements({flatten:!0})[0];typeof t?.focus=="function"&&t.focus()}getMenu(){return this.panel.assignedElements({flatten:!0}).find(t=>t.tagName.toLowerCase()==="sl-menu")}handleTriggerClick(){this.open?this.hide():(this.show(),this.focusOnTrigger())}async handleTriggerKeyDown(t){if([" ","Enter"].includes(t.key)){t.preventDefault(),this.handleTriggerClick();return}const r=this.getMenu();if(r){const o=r.getAllItems(),i=o[0],l=o[o.length-1];["ArrowDown","ArrowUp","Home","End"].includes(t.key)&&(t.preventDefault(),this.open||(this.show(),await this.updateComplete),o.length>0&&this.updateComplete.then(()=>{(t.key==="ArrowDown"||t.key==="Home")&&(r.setCurrentItem(i),i.focus()),(t.key==="ArrowUp"||t.key==="End")&&(r.setCurrentItem(l),l.focus())}))}}handleTriggerKeyUp(t){t.key===" "&&t.preventDefault()}handleTriggerSlotChange(){this.updateAccessibleTrigger()}updateAccessibleTrigger(){const r=this.trigger.assignedElements({flatten:!0}).find(i=>rc(i).start);let o;if(r){switch(r.tagName.toLowerCase()){case"sl-button":case"sl-icon-button":o=r.button;break;default:o=r}o.setAttribute("aria-haspopup","true"),o.setAttribute("aria-expanded",this.open?"true":"false")}}async show(){if(!this.open)return this.open=!0,Cr(this,"sl-after-show")}async hide(){if(this.open)return this.open=!1,Cr(this,"sl-after-hide")}reposition(){this.popup.reposition()}addOpenListeners(){var t;this.panel.addEventListener("sl-select",this.handlePanelSelect),"CloseWatcher"in window?((t=this.closeWatcher)==null||t.destroy(),this.closeWatcher=new CloseWatcher,this.closeWatcher.onclose=()=>{this.hide(),this.focusOnTrigger()}):this.panel.addEventListener("keydown",this.handleKeyDown),document.addEventListener("keydown",this.handleDocumentKeyDown),document.addEventListener("mousedown",this.handleDocumentMouseDown)}removeOpenListeners(){var t;this.panel&&(this.panel.removeEventListener("sl-select",this.handlePanelSelect),this.panel.removeEventListener("keydown",this.handleKeyDown)),document.removeEventListener("keydown",this.handleDocumentKeyDown),document.removeEventListener("mousedown",this.handleDocumentMouseDown),(t=this.closeWatcher)==null||t.destroy()}async handleOpenChange(){if(this.disabled){this.open=!1;return}if(this.updateAccessibleTrigger(),this.open){this.emit("sl-show"),this.addOpenListeners(),await Be(this),this.panel.hidden=!1,this.popup.active=!0;const{keyframes:t,options:r}=ke(this,"dropdown.show",{dir:this.localize.dir()});await Ce(this.popup.popup,t,r),this.emit("sl-after-show")}else{this.emit("sl-hide"),this.removeOpenListeners(),await Be(this);const{keyframes:t,options:r}=ke(this,"dropdown.hide",{dir:this.localize.dir()});await Ce(this.popup.popup,t,r),this.panel.hidden=!0,this.popup.active=!1,this.emit("sl-after-hide")}}render(){return X`
+      <sl-popup
+        part="base"
+        exportparts="popup:base__popup"
+        id="dropdown"
+        placement=${this.placement}
+        distance=${this.distance}
+        skidding=${this.skidding}
+        strategy=${this.hoist?"fixed":"absolute"}
+        flip
+        shift
+        auto-size="vertical"
+        auto-size-padding="10"
+        sync=${Y(this.sync?this.sync:void 0)}
+        class=${kt({dropdown:!0,"dropdown--open":this.open})}
+      >
+        <slot
+          name="trigger"
+          slot="anchor"
+          part="trigger"
+          class="dropdown__trigger"
+          @click=${this.handleTriggerClick}
+          @keydown=${this.handleTriggerKeyDown}
+          @keyup=${this.handleTriggerKeyUp}
+          @slotchange=${this.handleTriggerSlotChange}
+        ></slot>
+
+        <div aria-hidden=${this.open?"false":"true"} aria-labelledby="dropdown">
+          <slot part="panel" class="dropdown__panel"></slot>
+        </div>
+      </sl-popup>
+    `}};qt.styles=[St,$d];qt.dependencies={"sl-popup":bt};f([st(".dropdown")],qt.prototype,"popup",2);f([st(".dropdown__trigger")],qt.prototype,"trigger",2);f([st(".dropdown__panel")],qt.prototype,"panel",2);f([C({type:Boolean,reflect:!0})],qt.prototype,"open",2);f([C({reflect:!0})],qt.prototype,"placement",2);f([C({type:Boolean,reflect:!0})],qt.prototype,"disabled",2);f([C({attribute:"stay-open-on-select",type:Boolean,reflect:!0})],qt.prototype,"stayOpenOnSelect",2);f([C({attribute:!1})],qt.prototype,"containingElement",2);f([C({type:Number})],qt.prototype,"distance",2);f([C({type:Number})],qt.prototype,"skidding",2);f([C({type:Boolean})],qt.prototype,"hoist",2);f([C({reflect:!0})],qt.prototype,"sync",2);f([ht("open",{waitUntilFirstUpdate:!0})],qt.prototype,"handleOpenChange",1);Se("dropdown.show",{keyframes:[{opacity:0,scale:.9},{opacity:1,scale:1}],options:{duration:100,easing:"ease"}});Se("dropdown.hide",{keyframes:[{opacity:1,scale:1},{opacity:0,scale:.9}],options:{duration:100,easing:"ease"}});qt.define("sl-dropdown");var Ad=ct`
+  :host {
+    --submenu-offset: -2px;
+
+    display: block;
+  }
+
+  :host([inert]) {
+    display: none;
+  }
+
+  .menu-item {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+    font-weight: var(--sl-font-weight-normal);
+    line-height: var(--sl-line-height-normal);
+    letter-spacing: var(--sl-letter-spacing-normal);
+    color: var(--sl-color-neutral-700);
+    padding: var(--sl-spacing-2x-small) var(--sl-spacing-2x-small);
+    transition: var(--sl-transition-fast) fill;
+    user-select: none;
+    -webkit-user-select: none;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .menu-item.menu-item--disabled {
+    outline: none;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .menu-item.menu-item--loading {
+    outline: none;
+    cursor: wait;
+  }
+
+  .menu-item.menu-item--loading *:not(sl-spinner) {
+    opacity: 0.5;
+  }
+
+  .menu-item--loading sl-spinner {
+    --indicator-color: currentColor;
+    --track-width: 1px;
+    position: absolute;
+    font-size: 0.75em;
+    top: calc(50% - 0.5em);
+    left: 0.65rem;
+    opacity: 1;
+  }
+
+  .menu-item .menu-item__label {
+    flex: 1 1 auto;
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  .menu-item .menu-item__prefix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__prefix::slotted(*) {
+    margin-inline-end: var(--sl-spacing-x-small);
+  }
+
+  .menu-item .menu-item__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-item .menu-item__suffix::slotted(*) {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+
+  /* Safe triangle */
+  .menu-item--submenu-expanded::after {
+    content: '';
+    position: fixed;
+    z-index: calc(var(--sl-z-index-dropdown) - 1);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    clip-path: polygon(
+      var(--safe-triangle-cursor-x, 0) var(--safe-triangle-cursor-y, 0),
+      var(--safe-triangle-submenu-start-x, 0) var(--safe-triangle-submenu-start-y, 0),
+      var(--safe-triangle-submenu-end-x, 0) var(--safe-triangle-submenu-end-y, 0)
+    );
+  }
+
+  :host(:focus-visible) {
+    outline: none;
+  }
+
+  :host(:hover:not([aria-disabled='true'], :focus-visible)) .menu-item,
+  .menu-item--submenu-expanded {
+    background-color: var(--sl-color-neutral-100);
+    color: var(--sl-color-neutral-1000);
+  }
+
+  :host(:focus-visible) .menu-item {
+    outline: none;
+    background-color: var(--sl-color-primary-600);
+    color: var(--sl-color-neutral-0);
+    opacity: 1;
+  }
+
+  .menu-item .menu-item__check,
+  .menu-item .menu-item__chevron {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5em;
+    visibility: hidden;
+  }
+
+  .menu-item--checked .menu-item__check,
+  .menu-item--has-submenu .menu-item__chevron {
+    visibility: visible;
+  }
+
+  /* Add elevation and z-index to submenus */
+  sl-popup::part(popup) {
+    box-shadow: var(--sl-shadow-large);
+    z-index: var(--sl-z-index-dropdown);
+    margin-left: var(--submenu-offset);
+  }
+
+  .menu-item--rtl sl-popup::part(popup) {
+    margin-left: calc(-1 * var(--submenu-offset));
+  }
+
+  @media (forced-colors: active) {
+    :host(:hover:not([aria-disabled='true'])) .menu-item,
+    :host(:focus-visible) .menu-item {
+      outline: dashed 1px SelectedItem;
+      outline-offset: -1px;
+    }
+  }
+
+  ::slotted(sl-menu) {
+    max-width: var(--auto-size-available-width) !important;
+    max-height: var(--auto-size-available-height) !important;
+  }
+`;const ln=(t,r)=>{const o=t._$AN;if(o===void 0)return!1;for(const i of o)i._$AO?.(r,!1),ln(i,r);return!0},uo=t=>{let r,o;do{if((r=t._$AM)===void 0)break;o=r._$AN,o.delete(t),t=r}while(o?.size===0)},Na=t=>{for(let r;r=t._$AM;t=r){let o=r._$AN;if(o===void 0)r._$AN=o=new Set;else if(o.has(t))break;o.add(t),Td(r)}};function Sd(t){this._$AN!==void 0?(uo(this),this._$AM=t,Na(this)):this._$AM=t}function Ed(t,r=!1,o=0){const i=this._$AH,l=this._$AN;if(l!==void 0&&l.size!==0)if(r)if(Array.isArray(i))for(let c=o;c<i.length;c++)ln(i[c],!1),uo(i[c]);else i!=null&&(ln(i,!1),uo(i));else ln(this,t)}const Td=t=>{t.type==xe.CHILD&&(t._$AP??(t._$AP=Ed),t._$AQ??(t._$AQ=Sd))};class Od extends vo{constructor(){super(...arguments),this._$AN=void 0}_$AT(r,o,i){super._$AT(r,o,i),Na(this),this.isConnected=r._$AU}_$AO(r,o=!0){r!==this.isConnected&&(this.isConnected=r,r?this.reconnected?.():this.disconnected?.()),o&&(ln(this,r),uo(this))}setValue(r){if($a(this._$Ct))this._$Ct._$AI(r,this);else{const o=[...this._$Ct._$AH];o[this._$Ci]=r,this._$Ct._$AI(o,this,0)}}disconnected(){}reconnected(){}}const Pd=()=>new zd;class zd{}const yi=new WeakMap,Md=mo(class extends Od{render(t){return xt}update(t,[r]){const o=r!==this.G;return o&&this.G!==void 0&&this.rt(void 0),(o||this.lt!==this.ct)&&(this.G=r,this.ht=t.options?.host,this.rt(this.ct=t.element)),xt}rt(t){if(this.isConnected||(t=void 0),typeof this.G=="function"){const r=this.ht??globalThis;let o=yi.get(r);o===void 0&&(o=new WeakMap,yi.set(r,o)),o.get(this.G)!==void 0&&this.G.call(this.ht,void 0),o.set(this.G,t),t!==void 0&&this.G.call(this.ht,t)}else this.G.value=t}get lt(){return typeof this.G=="function"?yi.get(this.ht??globalThis)?.get(this.G):this.G?.value}disconnected(){this.lt===this.ct&&this.rt(void 0)}reconnected(){this.rt(this.ct)}});var Dd=class{constructor(t,r){this.popupRef=Pd(),this.enableSubmenuTimer=-1,this.isConnected=!1,this.isPopupConnected=!1,this.skidding=0,this.submenuOpenDelay=100,this.handleMouseMove=o=>{this.host.style.setProperty("--safe-triangle-cursor-x",`${o.clientX}px`),this.host.style.setProperty("--safe-triangle-cursor-y",`${o.clientY}px`)},this.handleMouseOver=()=>{this.hasSlotController.test("submenu")&&this.enableSubmenu()},this.handleKeyDown=o=>{switch(o.key){case"Escape":case"Tab":this.disableSubmenu();break;case"ArrowLeft":o.target!==this.host&&(o.preventDefault(),o.stopPropagation(),this.host.focus(),this.disableSubmenu());break;case"ArrowRight":case"Enter":case" ":this.handleSubmenuEntry(o);break}},this.handleClick=o=>{var i;o.target===this.host?(o.preventDefault(),o.stopPropagation()):o.target instanceof Element&&(o.target.tagName==="sl-menu-item"||(i=o.target.role)!=null&&i.startsWith("menuitem"))&&this.disableSubmenu()},this.handleFocusOut=o=>{o.relatedTarget&&o.relatedTarget instanceof Element&&this.host.contains(o.relatedTarget)||this.disableSubmenu()},this.handlePopupMouseover=o=>{o.stopPropagation()},this.handlePopupReposition=()=>{const o=this.host.renderRoot.querySelector("slot[name='submenu']"),i=o?.assignedElements({flatten:!0}).filter(O=>O.localName==="sl-menu")[0],l=getComputedStyle(this.host).direction==="rtl";if(!i)return;const{left:c,top:h,width:m,height:k}=i.getBoundingClientRect();this.host.style.setProperty("--safe-triangle-submenu-start-x",`${l?c+m:c}px`),this.host.style.setProperty("--safe-triangle-submenu-start-y",`${h}px`),this.host.style.setProperty("--safe-triangle-submenu-end-x",`${l?c+m:c}px`),this.host.style.setProperty("--safe-triangle-submenu-end-y",`${h+k}px`)},(this.host=t).addController(this),this.hasSlotController=r}hostConnected(){this.hasSlotController.test("submenu")&&!this.host.disabled&&this.addListeners()}hostDisconnected(){this.removeListeners()}hostUpdated(){this.hasSlotController.test("submenu")&&!this.host.disabled?(this.addListeners(),this.updateSkidding()):this.removeListeners()}addListeners(){this.isConnected||(this.host.addEventListener("mousemove",this.handleMouseMove),this.host.addEventListener("mouseover",this.handleMouseOver),this.host.addEventListener("keydown",this.handleKeyDown),this.host.addEventListener("click",this.handleClick),this.host.addEventListener("focusout",this.handleFocusOut),this.isConnected=!0),this.isPopupConnected||this.popupRef.value&&(this.popupRef.value.addEventListener("mouseover",this.handlePopupMouseover),this.popupRef.value.addEventListener("sl-reposition",this.handlePopupReposition),this.isPopupConnected=!0)}removeListeners(){this.isConnected&&(this.host.removeEventListener("mousemove",this.handleMouseMove),this.host.removeEventListener("mouseover",this.handleMouseOver),this.host.removeEventListener("keydown",this.handleKeyDown),this.host.removeEventListener("click",this.handleClick),this.host.removeEventListener("focusout",this.handleFocusOut),this.isConnected=!1),this.isPopupConnected&&this.popupRef.value&&(this.popupRef.value.removeEventListener("mouseover",this.handlePopupMouseover),this.popupRef.value.removeEventListener("sl-reposition",this.handlePopupReposition),this.isPopupConnected=!1)}handleSubmenuEntry(t){const r=this.host.renderRoot.querySelector("slot[name='submenu']");if(!r){console.error("Cannot activate a submenu if no corresponding menuitem can be found.",this);return}let o=null;for(const i of r.assignedElements())if(o=i.querySelectorAll("sl-menu-item, [role^='menuitem']"),o.length!==0)break;if(!(!o||o.length===0)){o[0].setAttribute("tabindex","0");for(let i=1;i!==o.length;++i)o[i].setAttribute("tabindex","-1");this.popupRef.value&&(t.preventDefault(),t.stopPropagation(),this.popupRef.value.active?o[0]instanceof HTMLElement&&o[0].focus():(this.enableSubmenu(!1),this.host.updateComplete.then(()=>{o[0]instanceof HTMLElement&&o[0].focus()}),this.host.requestUpdate()))}}setSubmenuState(t){this.popupRef.value&&this.popupRef.value.active!==t&&(this.popupRef.value.active=t,this.host.requestUpdate())}enableSubmenu(t=!0){t?(window.clearTimeout(this.enableSubmenuTimer),this.enableSubmenuTimer=window.setTimeout(()=>{this.setSubmenuState(!0)},this.submenuOpenDelay)):this.setSubmenuState(!0)}disableSubmenu(){window.clearTimeout(this.enableSubmenuTimer),this.setSubmenuState(!1)}updateSkidding(){var t;if(!((t=this.host.parentElement)!=null&&t.computedStyleMap))return;const r=this.host.parentElement.computedStyleMap(),i=["padding-top","border-top-width","margin-top"].reduce((l,c)=>{var h;const m=(h=r.get(c))!=null?h:new CSSUnitValue(0,"px"),O=(m instanceof CSSUnitValue?m:new CSSUnitValue(0,"px")).to("px");return l-O.value},0);this.skidding=i}isExpanded(){return this.popupRef.value?this.popupRef.value.active:!1}renderSubmenu(){const t=getComputedStyle(this.host).direction==="rtl";return this.isConnected?X`
+      <sl-popup
+        ${Md(this.popupRef)}
+        placement=${t?"left-start":"right-start"}
+        anchor="anchor"
+        flip
+        flip-fallback-strategy="best-fit"
+        skidding="${this.skidding}"
+        strategy="fixed"
+        auto-size="vertical"
+        auto-size-padding="10"
+      >
+        <slot name="submenu"></slot>
+      </sl-popup>
+    `:X` <slot name="submenu" hidden></slot> `}},Jt=class extends gt{constructor(){super(...arguments),this.localize=new ve(this),this.type="normal",this.checked=!1,this.value="",this.loading=!1,this.disabled=!1,this.hasSlotController=new Ke(this,"submenu"),this.submenuController=new Dd(this,this.hasSlotController),this.handleHostClick=t=>{this.disabled&&(t.preventDefault(),t.stopImmediatePropagation())},this.handleMouseOver=t=>{this.focus(),t.stopPropagation()}}connectedCallback(){super.connectedCallback(),this.addEventListener("click",this.handleHostClick),this.addEventListener("mouseover",this.handleMouseOver)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener("click",this.handleHostClick),this.removeEventListener("mouseover",this.handleMouseOver)}handleDefaultSlotChange(){const t=this.getTextLabel();if(typeof this.cachedTextLabel>"u"){this.cachedTextLabel=t;return}t!==this.cachedTextLabel&&(this.cachedTextLabel=t,this.emit("slotchange",{bubbles:!0,composed:!1,cancelable:!1}))}handleCheckedChange(){if(this.checked&&this.type!=="checkbox"){this.checked=!1,console.error('The checked attribute can only be used on menu items with type="checkbox"',this);return}this.type==="checkbox"?this.setAttribute("aria-checked",this.checked?"true":"false"):this.removeAttribute("aria-checked")}handleDisabledChange(){this.setAttribute("aria-disabled",this.disabled?"true":"false")}handleTypeChange(){this.type==="checkbox"?(this.setAttribute("role","menuitemcheckbox"),this.setAttribute("aria-checked",this.checked?"true":"false")):(this.setAttribute("role","menuitem"),this.removeAttribute("aria-checked"))}getTextLabel(){return ju(this.defaultSlot)}isSubmenu(){return this.hasSlotController.test("submenu")}render(){const t=this.localize.dir()==="rtl",r=this.submenuController.isExpanded();return X`
+      <div
+        id="anchor"
+        part="base"
+        class=${kt({"menu-item":!0,"menu-item--rtl":t,"menu-item--checked":this.checked,"menu-item--disabled":this.disabled,"menu-item--loading":this.loading,"menu-item--has-submenu":this.isSubmenu(),"menu-item--submenu-expanded":r})}
+        ?aria-haspopup="${this.isSubmenu()}"
+        ?aria-expanded="${!!r}"
+      >
+        <span part="checked-icon" class="menu-item__check">
+          <sl-icon name="check" library="system" aria-hidden="true"></sl-icon>
+        </span>
+
+        <slot name="prefix" part="prefix" class="menu-item__prefix"></slot>
+
+        <slot part="label" class="menu-item__label" @slotchange=${this.handleDefaultSlotChange}></slot>
+
+        <slot name="suffix" part="suffix" class="menu-item__suffix"></slot>
+
+        <span part="submenu-icon" class="menu-item__chevron">
+          <sl-icon name=${t?"chevron-left":"chevron-right"} library="system" aria-hidden="true"></sl-icon>
+        </span>
+
+        ${this.submenuController.renderSubmenu()}
+        ${this.loading?X` <sl-spinner part="spinner" exportparts="base:spinner__base"></sl-spinner> `:""}
+      </div>
+    `}};Jt.styles=[St,Ad];Jt.dependencies={"sl-icon":Ut,"sl-popup":bt,"sl-spinner":Ii};f([st("slot:not([name])")],Jt.prototype,"defaultSlot",2);f([st(".menu-item")],Jt.prototype,"menuItem",2);f([C()],Jt.prototype,"type",2);f([C({type:Boolean,reflect:!0})],Jt.prototype,"checked",2);f([C()],Jt.prototype,"value",2);f([C({type:Boolean,reflect:!0})],Jt.prototype,"loading",2);f([C({type:Boolean,reflect:!0})],Jt.prototype,"disabled",2);f([ht("checked")],Jt.prototype,"handleCheckedChange",1);f([ht("disabled")],Jt.prototype,"handleDisabledChange",1);f([ht("type")],Jt.prototype,"handleTypeChange",1);Jt.define("sl-menu-item");var Rd=ct`
+  :host {
+    display: block;
+    position: relative;
+    background: var(--sl-panel-background-color);
+    border: solid var(--sl-panel-border-width) var(--sl-panel-border-color);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-x-small) 0;
+    overflow: auto;
+    overscroll-behavior: none;
+  }
+
+  ::slotted(sl-divider) {
+    --spacing: var(--sl-spacing-x-small);
+  }
+`,Hi=class extends gt{connectedCallback(){super.connectedCallback(),this.setAttribute("role","menu")}handleClick(t){const r=["menuitem","menuitemcheckbox"],o=t.composedPath(),i=o.find(m=>{var k;return r.includes(((k=m?.getAttribute)==null?void 0:k.call(m,"role"))||"")});if(!i||o.find(m=>{var k;return((k=m?.getAttribute)==null?void 0:k.call(m,"role"))==="menu"})!==this)return;const h=i;h.type==="checkbox"&&(h.checked=!h.checked),this.emit("sl-select",{detail:{item:h}})}handleKeyDown(t){if(t.key==="Enter"||t.key===" "){const r=this.getCurrentItem();t.preventDefault(),t.stopPropagation(),r?.click()}else if(["ArrowDown","ArrowUp","Home","End"].includes(t.key)){const r=this.getAllItems(),o=this.getCurrentItem();let i=o?r.indexOf(o):0;r.length>0&&(t.preventDefault(),t.stopPropagation(),t.key==="ArrowDown"?i++:t.key==="ArrowUp"?i--:t.key==="Home"?i=0:t.key==="End"&&(i=r.length-1),i<0&&(i=r.length-1),i>r.length-1&&(i=0),this.setCurrentItem(r[i]),r[i].focus())}}handleMouseDown(t){const r=t.target;this.isMenuItem(r)&&this.setCurrentItem(r)}handleSlotChange(){const t=this.getAllItems();t.length>0&&this.setCurrentItem(t[0])}isMenuItem(t){var r;return t.tagName.toLowerCase()==="sl-menu-item"||["menuitem","menuitemcheckbox","menuitemradio"].includes((r=t.getAttribute("role"))!=null?r:"")}getAllItems(){return[...this.defaultSlot.assignedElements({flatten:!0})].filter(t=>!(t.inert||!this.isMenuItem(t)))}getCurrentItem(){return this.getAllItems().find(t=>t.getAttribute("tabindex")==="0")}setCurrentItem(t){this.getAllItems().forEach(o=>{o.setAttribute("tabindex",o===t?"0":"-1")})}render(){return X`
+      <slot
+        @slotchange=${this.handleSlotChange}
+        @click=${this.handleClick}
+        @keydown=${this.handleKeyDown}
+        @mousedown=${this.handleMouseDown}
+      ></slot>
+    `}};Hi.styles=[St,Rd];f([st("slot")],Hi.prototype,"defaultSlot",2);Hi.define("sl-menu");const ca=(t,r,o)=>{const i=new Map;for(let l=r;l<=o;l++)i.set(t[l],l);return i},wi=mo(class extends vo{constructor(t){if(super(t),t.type!==xe.CHILD)throw Error("repeat() can only be used in text expressions")}dt(t,r,o){let i;o===void 0?o=r:r!==void 0&&(i=r);const l=[],c=[];let h=0;for(const m of t)l[h]=i?i(m,h):h,c[h]=o(m,h),h++;return{values:c,keys:l}}render(t,r,o){return this.dt(t,r,o).values}update(t,[r,o,i]){const l=Gu(t),{values:c,keys:h}=this.dt(r,o,i);if(!Array.isArray(l))return this.ut=h,c;const m=this.ut??(this.ut=[]),k=[];let O,D,P=0,F=l.length-1,R=0,N=c.length-1;for(;P<=F&&R<=N;)if(l[P]===null)P++;else if(l[F]===null)F--;else if(m[P]===h[R])k[R]=nr(l[P],c[R]),P++,R++;else if(m[F]===h[N])k[N]=nr(l[F],c[N]),F--,N--;else if(m[P]===h[N])k[N]=nr(l[P],c[N]),Jr(t,k[N+1],l[P]),P++,N--;else if(m[F]===h[R])k[R]=nr(l[F],c[R]),Jr(t,l[P],l[F]),F--,R++;else if(O===void 0&&(O=ca(h,R,N),D=ca(m,P,F)),O.has(m[P]))if(O.has(m[F])){const W=D.get(h[R]),tt=W!==void 0?l[W]:null;if(tt===null){const J=Jr(t,l[P]);nr(J,c[R]),k[R]=J}else k[R]=nr(tt,c[R]),Jr(t,l[P],tt),l[W]=null;R++}else fi(l[F]),F--;else fi(l[P]),P++;for(;R<=N;){const W=Jr(t,k[N+1]);nr(W,c[R]),k[R++]=W}for(;P<=F;){const W=l[P++];W!==null&&fi(W)}return this.ut=h,Aa(t,k),ne}});var Bd=typeof globalThis<"u"?globalThis:typeof window<"u"?window:typeof global<"u"?global:typeof self<"u"?self:{};function Id(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}var Jn={exports:{}},Ld=Jn.exports,da;function Fd(){return da||(da=1,(function(t,r){(function(o,i){t.exports=i()})(Ld,function(){var o=function(e,n){return(o=Object.setPrototypeOf||{__proto__:[]}instanceof Array&&function(s,a){s.__proto__=a}||function(s,a){for(var u in a)Object.prototype.hasOwnProperty.call(a,u)&&(s[u]=a[u])})(e,n)},i=function(){return(i=Object.assign||function(e){for(var n,s=1,a=arguments.length;s<a;s++)for(var u in n=arguments[s])Object.prototype.hasOwnProperty.call(n,u)&&(e[u]=n[u]);return e}).apply(this,arguments)};function l(e,n,s){for(var a,u=0,d=n.length;u<d;u++)!a&&u in n||((a=a||Array.prototype.slice.call(n,0,u))[u]=n[u]);return e.concat(a||Array.prototype.slice.call(n))}var c=typeof globalThis<"u"?globalThis:typeof self<"u"?self:typeof window<"u"?window:Bd,h=Object.keys,m=Array.isArray;function k(e,n){return typeof n!="object"||h(n).forEach(function(s){e[s]=n[s]}),e}typeof Promise>"u"||c.Promise||(c.Promise=Promise);var O=Object.getPrototypeOf,D={}.hasOwnProperty;function P(e,n){return D.call(e,n)}function F(e,n){typeof n=="function"&&(n=n(O(e))),(typeof Reflect>"u"?h:Reflect.ownKeys)(n).forEach(function(s){N(e,s,n[s])})}var R=Object.defineProperty;function N(e,n,s,a){R(e,n,k(s&&P(s,"get")&&typeof s.get=="function"?{get:s.get,set:s.set,configurable:!0}:{value:s,configurable:!0,writable:!0},a))}function W(e){return{from:function(n){return e.prototype=Object.create(n.prototype),N(e.prototype,"constructor",e),{extend:F.bind(null,e.prototype)}}}}var tt=Object.getOwnPropertyDescriptor,J=[].slice;function ot(e,n,s){return J.call(e,n,s)}function dt(e,n){return n(e)}function yt(e){if(!e)throw new Error("Assertion Failed")}function vt(e){c.setImmediate?setImmediate(e):setTimeout(e,0)}function Ct(e,n){if(typeof n=="string"&&P(e,n))return e[n];if(!n)return e;if(typeof n!="string"){for(var s=[],a=0,u=n.length;a<u;++a){var d=Ct(e,n[a]);s.push(d)}return s}var p=n.indexOf(".");if(p!==-1){var b=e[n.substr(0,p)];return b==null?void 0:Ct(b,n.substr(p+1))}}function ut(e,n,s){if(e&&n!==void 0&&!("isFrozen"in Object&&Object.isFrozen(e)))if(typeof n!="string"&&"length"in n){yt(typeof s!="string"&&"length"in s);for(var a=0,u=n.length;a<u;++a)ut(e,n[a],s[a])}else{var d,p,b=n.indexOf(".");b!==-1?(d=n.substr(0,b),(p=n.substr(b+1))===""?s===void 0?m(e)&&!isNaN(parseInt(d))?e.splice(d,1):delete e[d]:e[d]=s:ut(b=!(b=e[d])||!P(e,d)?e[d]={}:b,p,s)):s===void 0?m(e)&&!isNaN(parseInt(n))?e.splice(n,1):delete e[n]:e[n]=s}}function te(e){var n,s={};for(n in e)P(e,n)&&(s[n]=e[n]);return s}var ee=[].concat;function jt(e){return ee.apply([],e)}var Ue="BigUint64Array,BigInt64Array,Array,Boolean,String,Date,RegExp,Blob,File,FileList,FileSystemFileHandle,FileSystemDirectoryHandle,ArrayBuffer,DataView,Uint8ClampedArray,ImageBitmap,ImageData,Map,Set,CryptoKey".split(",").concat(jt([8,16,32,64].map(function(e){return["Int","Uint","Float"].map(function(n){return n+e+"Array"})}))).filter(function(e){return c[e]}),oe=new Set(Ue.map(function(e){return c[e]})),Bt=null;function It(e){return Bt=new WeakMap,e=(function n(s){if(!s||typeof s!="object")return s;var a=Bt.get(s);if(a)return a;if(m(s)){a=[],Bt.set(s,a);for(var u=0,d=s.length;u<d;++u)a.push(n(s[u]))}else if(oe.has(s.constructor))a=s;else{var p,b=O(s);for(p in a=b===Object.prototype?{}:Object.create(b),Bt.set(s,a),s)P(s,p)&&(a[p]=n(s[p]))}return a})(e),Bt=null,e}var zt={}.toString;function ie(e){return zt.call(e).slice(8,-1)}var Wt=typeof Symbol<"u"?Symbol.iterator:"@@iterator",Gt=typeof Wt=="symbol"?function(e){var n;return e!=null&&(n=e[Wt])&&n.apply(e)}:function(){return null};function Et(e,n){return n=e.indexOf(n),0<=n&&e.splice(n,1),0<=n}var Kt={};function se(e){var n,s,a,u;if(arguments.length===1){if(m(e))return e.slice();if(this===Kt&&typeof e=="string")return[e];if(u=Gt(e)){for(s=[];!(a=u.next()).done;)s.push(a.value);return s}if(e==null)return[e];if(typeof(n=e.length)!="number")return[e];for(s=new Array(n);n--;)s[n]=e[n];return s}for(n=arguments.length,s=new Array(n);n--;)s[n]=arguments[n];return s}var Eo=typeof Symbol<"u"?function(e){return e[Symbol.toStringTag]==="AsyncFunction"}:function(){return!1},Ir=["Unknown","Constraint","Data","TransactionInactive","ReadOnly","Version","NotFound","InvalidState","InvalidAccess","Abort","Timeout","QuotaExceeded","Syntax","DataClone"],re=["Modify","Bulk","OpenFailed","VersionChange","Schema","Upgrade","InvalidTable","MissingAPI","NoSuchDatabase","InvalidArgument","SubTransaction","Unsupported","Internal","DatabaseClosed","PrematureCommit","ForeignAwait"].concat(Ir),Ka={VersionChanged:"Database version changed by other database connection",DatabaseClosed:"Database has been closed",Abort:"Transaction aborted",TransactionInactive:"Transaction has already completed or failed",MissingAPI:"IndexedDB API missing. Please visit https://tinyurl.com/y2uuvskb"};function ur(e,n){this.name=e,this.message=n}function Wi(e,n){return e+". Errors: "+Object.keys(n).map(function(s){return n[s].toString()}).filter(function(s,a,u){return u.indexOf(s)===a}).join(`
+`)}function yn(e,n,s,a){this.failures=n,this.failedKeys=a,this.successCount=s,this.message=Wi(e,n)}function cr(e,n){this.name="BulkError",this.failures=Object.keys(n).map(function(s){return n[s]}),this.failuresByPos=n,this.message=Wi(e,this.failures)}W(ur).from(Error).extend({toString:function(){return this.name+": "+this.message}}),W(yn).from(ur),W(cr).from(ur);var To=re.reduce(function(e,n){return e[n]=n+"Error",e},{}),Ha=ur,G=re.reduce(function(e,n){var s=n+"Error";function a(u,d){this.name=s,u?typeof u=="string"?(this.message="".concat(u).concat(d?`
+ `+d:""),this.inner=d||null):typeof u=="object"&&(this.message="".concat(u.name," ").concat(u.message),this.inner=u):(this.message=Ka[n]||s,this.inner=null)}return W(a).from(Ha),e[n]=a,e},{});G.Syntax=SyntaxError,G.Type=TypeError,G.Range=RangeError;var Gi=Ir.reduce(function(e,n){return e[n+"Error"]=G[n],e},{}),wn=re.reduce(function(e,n){return["Syntax","Type","Range"].indexOf(n)===-1&&(e[n+"Error"]=G[n]),e},{});function ft(){}function Rr(e){return e}function Ua(e,n){return e==null||e===Rr?n:function(s){return n(e(s))}}function He(e,n){return function(){e.apply(this,arguments),n.apply(this,arguments)}}function Wa(e,n){return e===ft?n:function(){var s=e.apply(this,arguments);s!==void 0&&(arguments[0]=s);var a=this.onsuccess,u=this.onerror;this.onsuccess=null,this.onerror=null;var d=n.apply(this,arguments);return a&&(this.onsuccess=this.onsuccess?He(a,this.onsuccess):a),u&&(this.onerror=this.onerror?He(u,this.onerror):u),d!==void 0?d:s}}function Ga(e,n){return e===ft?n:function(){e.apply(this,arguments);var s=this.onsuccess,a=this.onerror;this.onsuccess=this.onerror=null,n.apply(this,arguments),s&&(this.onsuccess=this.onsuccess?He(s,this.onsuccess):s),a&&(this.onerror=this.onerror?He(a,this.onerror):a)}}function Ya(e,n){return e===ft?n:function(s){var a=e.apply(this,arguments);k(s,a);var u=this.onsuccess,d=this.onerror;return this.onsuccess=null,this.onerror=null,s=n.apply(this,arguments),u&&(this.onsuccess=this.onsuccess?He(u,this.onsuccess):u),d&&(this.onerror=this.onerror?He(d,this.onerror):d),a===void 0?s===void 0?void 0:s:k(a,s)}}function Xa(e,n){return e===ft?n:function(){return n.apply(this,arguments)!==!1&&e.apply(this,arguments)}}function Oo(e,n){return e===ft?n:function(){var s=e.apply(this,arguments);if(s&&typeof s.then=="function"){for(var a=this,u=arguments.length,d=new Array(u);u--;)d[u]=arguments[u];return s.then(function(){return n.apply(a,d)})}return n.apply(this,arguments)}}wn.ModifyError=yn,wn.DexieError=ur,wn.BulkError=cr;var he=typeof location<"u"&&/^(http|https):\/\/(localhost|127\.0\.0\.1)/.test(location.href);function Yi(e){he=e}var Br={},Xi=100,Ue=typeof Promise>"u"?[]:(function(){var e=Promise.resolve();if(typeof crypto>"u"||!crypto.subtle)return[e,O(e),e];var n=crypto.subtle.digest("SHA-512",new Uint8Array([0]));return[n,O(n),e]})(),Ir=Ue[0],re=Ue[1],Ue=Ue[2],re=re&&re.then,We=Ir&&Ir.constructor,Po=!!Ue,Lr=function(e,n){Fr.push([e,n]),_n&&(queueMicrotask(Za),_n=!1)},zo=!0,_n=!0,Ge=[],xn=[],Mo=Rr,Ee={id:"global",global:!0,ref:0,unhandleds:[],onunhandled:ft,pgp:!1,env:{},finalize:ft},U=Ee,Fr=[],Ye=0,kn=[];function K(e){if(typeof this!="object")throw new TypeError("Promises must be constructed via new");this._listeners=[],this._lib=!1;var n=this._PSD=U;if(typeof e!="function"){if(e!==Br)throw new TypeError("Not a function");return this._state=arguments[1],this._value=arguments[2],void(this._state===!1&&Ro(this,this._value))}this._state=null,this._value=null,++n.ref,(function s(a,u){try{u(function(d){if(a._state===null){if(d===a)throw new TypeError("A promise cannot be resolved with itself.");var p=a._lib&&dr();d&&typeof d.then=="function"?s(a,function(b,g){d instanceof K?d._then(b,g):d.then(b,g)}):(a._state=!0,a._value=d,Zi(a)),p&&hr()}},Ro.bind(null,a))}catch(d){Ro(a,d)}})(this,e)}var Do={get:function(){var e=U,n=Sn;function s(a,u){var d=this,p=!e.global&&(e!==U||n!==Sn),b=p&&!Oe(),g=new K(function(y,$){Bo(d,new Qi(ts(a,e,p,b),ts(u,e,p,b),y,$,e))});return this._consoleTask&&(g._consoleTask=this._consoleTask),g}return s.prototype=Br,s},set:function(e){N(this,"then",e&&e.prototype===Br?Do:{get:function(){return e},set:Do.set})}};function Qi(e,n,s,a,u){this.onFulfilled=typeof e=="function"?e:null,this.onRejected=typeof n=="function"?n:null,this.resolve=s,this.reject=a,this.psd=u}function Ro(e,n){var s,a;xn.push(n),e._state===null&&(s=e._lib&&dr(),n=Mo(n),e._state=!1,e._value=n,a=e,Ge.some(function(u){return u._value===a._value})||Ge.push(a),Zi(e),s&&hr())}function Zi(e){var n=e._listeners;e._listeners=[];for(var s=0,a=n.length;s<a;++s)Bo(e,n[s]);var u=e._PSD;--u.ref||u.finalize(),Ye===0&&(++Ye,Lr(function(){--Ye==0&&Io()},[]))}function Bo(e,n){if(e._state!==null){var s=e._state?n.onFulfilled:n.onRejected;if(s===null)return(e._state?n.resolve:n.reject)(e._value);++n.psd.ref,++Ye,Lr(Qa,[s,e,n])}else e._listeners.push(n)}function Qa(e,n,s){try{var a,u=n._value;!n._state&&xn.length&&(xn=[]),a=he&&n._consoleTask?n._consoleTask.run(function(){return e(u)}):e(u),n._state||xn.indexOf(u)!==-1||(function(d){for(var p=Ge.length;p;)if(Ge[--p]._value===d._value)return Ge.splice(p,1)})(n),s.resolve(a)}catch(d){s.reject(d)}finally{--Ye==0&&Io(),--s.psd.ref||s.psd.finalize()}}function Za(){Xe(Ee,function(){dr()&&hr()})}function dr(){var e=zo;return _n=zo=!1,e}function hr(){var e,n,s;do for(;0<Fr.length;)for(e=Fr,Fr=[],s=e.length,n=0;n<s;++n){var a=e[n];a[0].apply(null,a[1])}while(0<Fr.length);_n=zo=!0}function Io(){var e=Ge;Ge=[],e.forEach(function(a){a._PSD.onunhandled.call(null,a._value,a)});for(var n=kn.slice(0),s=n.length;s;)n[--s]()}function Cn(e){return new K(Br,!1,e)}function wt(e,n){var s=U;return function(){var a=dr(),u=U;try{return Pe(s,!0),e.apply(this,arguments)}catch(d){n&&n(d)}finally{Pe(u,!1),a&&hr()}}}F(K.prototype,{then:Do,_then:function(e,n){Bo(this,new Qi(null,null,e,n,U))},catch:function(e){if(arguments.length===1)return this.then(null,e);var n=e,s=arguments[1];return typeof n=="function"?this.then(null,function(a){return(a instanceof n?s:Cn)(a)}):this.then(null,function(a){return(a&&a.name===n?s:Cn)(a)})},finally:function(e){return this.then(function(n){return K.resolve(e()).then(function(){return n})},function(n){return K.resolve(e()).then(function(){return Cn(n)})})},timeout:function(e,n){var s=this;return e<1/0?new K(function(a,u){var d=setTimeout(function(){return u(new G.Timeout(n))},e);s.then(a,u).finally(clearTimeout.bind(null,d))}):this}}),typeof Symbol<"u"&&Symbol.toStringTag&&N(K.prototype,Symbol.toStringTag,"Dexie.Promise"),Ee.env=Ji(),F(K,{all:function(){var e=se.apply(null,arguments).map(En);return new K(function(n,s){e.length===0&&n([]);var a=e.length;e.forEach(function(u,d){return K.resolve(u).then(function(p){e[d]=p,--a||n(e)},s)})})},resolve:function(e){return e instanceof K?e:e&&typeof e.then=="function"?new K(function(n,s){e.then(n,s)}):new K(Br,!0,e)},reject:Cn,race:function(){var e=se.apply(null,arguments).map(En);return new K(function(n,s){e.map(function(a){return K.resolve(a).then(n,s)})})},PSD:{get:function(){return U},set:function(e){return U=e}},totalEchoes:{get:function(){return Sn}},newPSD:Te,usePSD:Xe,scheduler:{get:function(){return Lr},set:function(e){Lr=e}},rejectionMapper:{get:function(){return Mo},set:function(e){Mo=e}},follow:function(e,n){return new K(function(s,a){return Te(function(u,d){var p=U;p.unhandleds=[],p.onunhandled=d,p.finalize=He(function(){var b,g=this;b=function(){g.unhandleds.length===0?u():d(g.unhandleds[0])},kn.push(function y(){b(),kn.splice(kn.indexOf(y),1)}),++Ye,Lr(function(){--Ye==0&&Io()},[])},p.finalize),e()},n,s,a)})}}),We&&(We.allSettled&&N(K,"allSettled",function(){var e=se.apply(null,arguments).map(En);return new K(function(n){e.length===0&&n([]);var s=e.length,a=new Array(s);e.forEach(function(u,d){return K.resolve(u).then(function(p){return a[d]={status:"fulfilled",value:p}},function(p){return a[d]={status:"rejected",reason:p}}).then(function(){return--s||n(a)})})})}),We.any&&typeof AggregateError<"u"&&N(K,"any",function(){var e=se.apply(null,arguments).map(En);return new K(function(n,s){e.length===0&&s(new AggregateError([]));var a=e.length,u=new Array(a);e.forEach(function(d,p){return K.resolve(d).then(function(b){return n(b)},function(b){u[p]=b,--a||s(new AggregateError(u))})})})}),We.withResolvers&&(K.withResolvers=We.withResolvers));var Tt={awaits:0,echoes:0,id:0},Ja=0,$n=[],An=0,Sn=0,tl=0;function Te(e,n,s,a){var u=U,d=Object.create(u);return d.parent=u,d.ref=0,d.global=!1,d.id=++tl,Ee.env,d.env=Po?{Promise:K,PromiseProp:{value:K,configurable:!0,writable:!0},all:K.all,race:K.race,allSettled:K.allSettled,any:K.any,resolve:K.resolve,reject:K.reject}:{},n&&k(d,n),++u.ref,d.finalize=function(){--this.parent.ref||this.parent.finalize()},a=Xe(d,e,s,a),d.ref===0&&d.finalize(),a}function pr(){return Tt.id||(Tt.id=++Ja),++Tt.awaits,Tt.echoes+=Xi,Tt.id}function Oe(){return!!Tt.awaits&&(--Tt.awaits==0&&(Tt.id=0),Tt.echoes=Tt.awaits*Xi,!0)}function En(e){return Tt.echoes&&e&&e.constructor===We?(pr(),e.then(function(n){return Oe(),n},function(n){return Oe(),$t(n)})):e}function el(){var e=$n[$n.length-1];$n.pop(),Pe(e,!1)}function Pe(e,n){var s,a=U;(n?!Tt.echoes||An++&&e===U:!An||--An&&e===U)||queueMicrotask(n?function(u){++Sn,Tt.echoes&&--Tt.echoes!=0||(Tt.echoes=Tt.awaits=Tt.id=0),$n.push(U),Pe(u,!0)}.bind(null,e):el),e!==U&&(U=e,a===Ee&&(Ee.env=Ji()),Po&&(s=Ee.env.Promise,n=e.env,(a.global||e.global)&&(Object.defineProperty(c,"Promise",n.PromiseProp),s.all=n.all,s.race=n.race,s.resolve=n.resolve,s.reject=n.reject,n.allSettled&&(s.allSettled=n.allSettled),n.any&&(s.any=n.any))))}function Ji(){var e=c.Promise;return Po?{Promise:e,PromiseProp:Object.getOwnPropertyDescriptor(c,"Promise"),all:e.all,race:e.race,allSettled:e.allSettled,any:e.any,resolve:e.resolve,reject:e.reject}:{}}function Xe(e,n,s,a,u){var d=U;try{return Pe(e,!0),n(s,a,u)}finally{Pe(d,!1)}}function ts(e,n,s,a){return typeof e!="function"?e:function(){var u=U;s&&pr(),Pe(n,!0);try{return e.apply(this,arguments)}finally{Pe(u,!1),a&&queueMicrotask(Oe)}}}function Lo(e){Promise===We&&Tt.echoes===0?An===0?e():enqueueNativeMicroTask(e):setTimeout(e,0)}(""+re).indexOf("[native code]")===-1&&(pr=Oe=ft);var $t=K.reject,Qe="￿",we="Invalid key provided. Keys must be of type string, number, Date or Array<string | number | Date>.",es="String expected.",fr=[],Tn="__dbnames",Fo="readonly",Vo="readwrite";function Ze(e,n){return e?n?function(){return e.apply(this,arguments)&&n.apply(this,arguments)}:e:n}var rs={type:3,lower:-1/0,lowerOpen:!1,upper:[[]],upperOpen:!1};function On(e){return typeof e!="string"||/\./.test(e)?function(n){return n}:function(n){return n[e]===void 0&&e in n&&delete(n=It(n))[e],n}}function ns(){throw G.Type("Entity instances must never be new:ed. Instances are generated by the framework bypassing the constructor.")}function it(e,n){try{var s=os(e),a=os(n);if(s!==a)return s==="Array"?1:a==="Array"?-1:s==="binary"?1:a==="binary"?-1:s==="string"?1:a==="string"?-1:s==="Date"?1:a!=="Date"?NaN:-1;switch(s){case"number":case"Date":case"string":return n<e?1:e<n?-1:0;case"binary":return(function(u,d){for(var p=u.length,b=d.length,g=p<b?p:b,y=0;y<g;++y)if(u[y]!==d[y])return u[y]<d[y]?-1:1;return p===b?0:p<b?-1:1})(is(e),is(n));case"Array":return(function(u,d){for(var p=u.length,b=d.length,g=p<b?p:b,y=0;y<g;++y){var $=it(u[y],d[y]);if($!==0)return $}return p===b?0:p<b?-1:1})(e,n)}}catch{}return NaN}function os(e){var n=typeof e;return n!="object"?n:ArrayBuffer.isView(e)?"binary":(e=ie(e),e==="ArrayBuffer"?"binary":e)}function is(e){return e instanceof Uint8Array?e:ArrayBuffer.isView(e)?new Uint8Array(e.buffer,e.byteOffset,e.byteLength):new Uint8Array(e)}function Pn(e,n,s){var a=e.schema.yProps;return a?(n&&0<s.numFailures&&(n=n.filter(function(u,d){return!s.failures[d]})),Promise.all(a.map(function(u){return u=u.updatesTable,n?e.db.table(u).where("k").anyOf(n).delete():e.db.table(u).clear()})).then(function(){return s})):s}var Vr=(ss.prototype.execute=function(e){var n=this["@@propmod"];if(n.add!==void 0){var s=n.add;if(m(s))return l(l([],m(e)?e:[],!0),s).sort();if(typeof s=="number")return(Number(e)||0)+s;if(typeof s=="bigint")try{return BigInt(e)+s}catch{return BigInt(0)+s}throw new TypeError("Invalid term ".concat(s))}if(n.remove!==void 0){var a=n.remove;if(m(a))return m(e)?e.filter(function(u){return!a.includes(u)}).sort():[];if(typeof a=="number")return Number(e)-a;if(typeof a=="bigint")try{return BigInt(e)-a}catch{return BigInt(0)-a}throw new TypeError("Invalid subtrahend ".concat(a))}return s=(s=n.replacePrefix)===null||s===void 0?void 0:s[0],s&&typeof e=="string"&&e.startsWith(s)?n.replacePrefix[1]+e.substring(s.length):e},ss);function ss(e){this["@@propmod"]=e}function as(e,n){for(var s=h(n),a=s.length,u=!1,d=0;d<a;++d){var p=s[d],b=n[p],g=Ct(e,p);b instanceof Vr?(ut(e,p,b.execute(g)),u=!0):g!==b&&(ut(e,p,b),u=!0)}return u}var ls=(mt.prototype._trans=function(e,n,s){var a=this._tx||U.trans,u=this.name,d=he&&typeof console<"u"&&console.createTask&&console.createTask("Dexie: ".concat(e==="readonly"?"read":"write"," ").concat(this.name));function p(y,$,v){if(!v.schema[u])throw new G.NotFound("Table "+u+" not part of transaction");return n(v.idbtrans,v)}var b=dr();try{var g=a&&a.db._novip===this.db._novip?a===U.trans?a._promise(e,p,s):Te(function(){return a._promise(e,p,s)},{trans:a,transless:U.transless||U}):(function y($,v,S,w){if($.idbdb&&($._state.openComplete||U.letThrough||$._vip)){var _=$._createTransaction(v,S,$._dbSchema);try{_.create(),$._state.PR1398_maxLoop=3}catch(x){return x.name===To.InvalidState&&$.isOpen()&&0<--$._state.PR1398_maxLoop?(console.warn("Dexie: Need to reopen db"),$.close({disableAutoOpen:!1}),$.open().then(function(){return y($,v,S,w)})):$t(x)}return _._promise(v,function(x,A){return Te(function(){return U.trans=_,w(x,A,_)})}).then(function(x){if(v==="readwrite")try{_.idbtrans.commit()}catch{}return v==="readonly"?x:_._completion.then(function(){return x})})}if($._state.openComplete)return $t(new G.DatabaseClosed($._state.dbOpenError));if(!$._state.isBeingOpened){if(!$._state.autoOpen)return $t(new G.DatabaseClosed);$.open().catch(ft)}return $._state.dbReadyPromise.then(function(){return y($,v,S,w)})})(this.db,e,[this.name],p);return d&&(g._consoleTask=d,g=g.catch(function(y){return console.trace(y),$t(y)})),g}finally{b&&hr()}},mt.prototype.get=function(e,n){var s=this;return e&&e.constructor===Object?this.where(e).first(n):e==null?$t(new G.Type("Invalid argument to Table.get()")):this._trans("readonly",function(a){return s.core.get({trans:a,key:e}).then(function(u){return s.hook.reading.fire(u)})}).then(n)},mt.prototype.where=function(e){if(typeof e=="string")return new this.db.WhereClause(this,e);if(m(e))return new this.db.WhereClause(this,"[".concat(e.join("+"),"]"));var n=h(e);if(n.length===1)return this.where(n[0]).equals(e[n[0]]);var s=this.schema.indexes.concat(this.schema.primKey).filter(function(b){if(b.compound&&n.every(function(y){return 0<=b.keyPath.indexOf(y)})){for(var g=0;g<n.length;++g)if(n.indexOf(b.keyPath[g])===-1)return!1;return!0}return!1}).sort(function(b,g){return b.keyPath.length-g.keyPath.length})[0];if(s&&this.db._maxKey!==Qe){var d=s.keyPath.slice(0,n.length);return this.where(d).equals(d.map(function(g){return e[g]}))}!s&&he&&console.warn("The query ".concat(JSON.stringify(e)," on ").concat(this.name," would benefit from a ")+"compound index [".concat(n.join("+"),"]"));var a=this.schema.idxByName;function u(b,g){return it(b,g)===0}var p=n.reduce(function(v,g){var y=v[0],$=v[1],v=a[g],S=e[g];return[y||v,y||!v?Ze($,v&&v.multi?function(w){return w=Ct(w,g),m(w)&&w.some(function(_){return u(S,_)})}:function(w){return u(S,Ct(w,g))}):$]},[null,null]),d=p[0],p=p[1];return d?this.where(d.name).equals(e[d.keyPath]).filter(p):s?this.filter(p):this.where(n).equals("")},mt.prototype.filter=function(e){return this.toCollection().and(e)},mt.prototype.count=function(e){return this.toCollection().count(e)},mt.prototype.offset=function(e){return this.toCollection().offset(e)},mt.prototype.limit=function(e){return this.toCollection().limit(e)},mt.prototype.each=function(e){return this.toCollection().each(e)},mt.prototype.toArray=function(e){return this.toCollection().toArray(e)},mt.prototype.toCollection=function(){return new this.db.Collection(new this.db.WhereClause(this))},mt.prototype.orderBy=function(e){return new this.db.Collection(new this.db.WhereClause(this,m(e)?"[".concat(e.join("+"),"]"):e))},mt.prototype.reverse=function(){return this.toCollection().reverse()},mt.prototype.mapToClass=function(e){var n,s=this.db,a=this.name;function u(){return n!==null&&n.apply(this,arguments)||this}(this.schema.mappedClass=e).prototype instanceof ns&&((function(g,y){if(typeof y!="function"&&y!==null)throw new TypeError("Class extends value "+String(y)+" is not a constructor or null");function $(){this.constructor=g}o(g,y),g.prototype=y===null?Object.create(y):($.prototype=y.prototype,new $)})(u,n=e),Object.defineProperty(u.prototype,"db",{get:function(){return s},enumerable:!1,configurable:!0}),u.prototype.table=function(){return a},e=u);for(var d=new Set,p=e.prototype;p;p=O(p))Object.getOwnPropertyNames(p).forEach(function(g){return d.add(g)});function b(g){if(!g)return g;var y,$=Object.create(e.prototype);for(y in g)if(!d.has(y))try{$[y]=g[y]}catch{}return $}return this.schema.readHook&&this.hook.reading.unsubscribe(this.schema.readHook),this.schema.readHook=b,this.hook("reading",b),e},mt.prototype.defineClass=function(){return this.mapToClass(function(e){k(this,e)})},mt.prototype.add=function(e,n){var s=this,a=this.schema.primKey,u=a.auto,d=a.keyPath,p=e;return d&&u&&(p=On(d)(e)),this._trans("readwrite",function(b){return s.core.mutate({trans:b,type:"add",keys:n!=null?[n]:null,values:[p]})}).then(function(b){return b.numFailures?K.reject(b.failures[0]):b.lastResult}).then(function(b){if(d)try{ut(e,d,b)}catch{}return b})},mt.prototype.upsert=function(e,n){var s=this,a=this.schema.primKey.keyPath;return this._trans("readwrite",function(u){return s.core.get({trans:u,key:e}).then(function(d){var p=d??{};return as(p,n),a&&ut(p,a,e),s.core.mutate({trans:u,type:"put",values:[p],keys:[e],upsert:!0,updates:{keys:[e],changeSpecs:[n]}}).then(function(b){return b.numFailures?K.reject(b.failures[0]):!!d})})})},mt.prototype.update=function(e,n){return typeof e!="object"||m(e)?this.where(":id").equals(e).modify(n):(e=Ct(e,this.schema.primKey.keyPath),e===void 0?$t(new G.InvalidArgument("Given object does not contain its primary key")):this.where(":id").equals(e).modify(n))},mt.prototype.put=function(e,n){var s=this,a=this.schema.primKey,u=a.auto,d=a.keyPath,p=e;return d&&u&&(p=On(d)(e)),this._trans("readwrite",function(b){return s.core.mutate({trans:b,type:"put",values:[p],keys:n!=null?[n]:null})}).then(function(b){return b.numFailures?K.reject(b.failures[0]):b.lastResult}).then(function(b){if(d)try{ut(e,d,b)}catch{}return b})},mt.prototype.delete=function(e){var n=this;return this._trans("readwrite",function(s){return n.core.mutate({trans:s,type:"delete",keys:[e]}).then(function(a){return Pn(n,[e],a)}).then(function(a){return a.numFailures?K.reject(a.failures[0]):void 0})})},mt.prototype.clear=function(){var e=this;return this._trans("readwrite",function(n){return e.core.mutate({trans:n,type:"deleteRange",range:rs}).then(function(s){return Pn(e,null,s)})}).then(function(n){return n.numFailures?K.reject(n.failures[0]):void 0})},mt.prototype.bulkGet=function(e){var n=this;return this._trans("readonly",function(s){return n.core.getMany({keys:e,trans:s}).then(function(a){return a.map(function(u){return n.hook.reading.fire(u)})})})},mt.prototype.bulkAdd=function(e,n,s){var a=this,u=Array.isArray(n)?n:void 0,d=(s=s||(u?void 0:n))?s.allKeys:void 0;return this._trans("readwrite",function(p){var y=a.schema.primKey,b=y.auto,y=y.keyPath;if(y&&u)throw new G.InvalidArgument("bulkAdd(): keys argument invalid on tables with inbound keys");if(u&&u.length!==e.length)throw new G.InvalidArgument("Arguments objects and keys must have the same length");var g=e.length,y=y&&b?e.map(On(y)):e;return a.core.mutate({trans:p,type:"add",keys:u,values:y,wantResults:d}).then(function(_){var v=_.numFailures,S=_.results,w=_.lastResult,_=_.failures;if(v===0)return d?S:w;throw new cr("".concat(a.name,".bulkAdd(): ").concat(v," of ").concat(g," operations failed"),_)})})},mt.prototype.bulkPut=function(e,n,s){var a=this,u=Array.isArray(n)?n:void 0,d=(s=s||(u?void 0:n))?s.allKeys:void 0;return this._trans("readwrite",function(p){var y=a.schema.primKey,b=y.auto,y=y.keyPath;if(y&&u)throw new G.InvalidArgument("bulkPut(): keys argument invalid on tables with inbound keys");if(u&&u.length!==e.length)throw new G.InvalidArgument("Arguments objects and keys must have the same length");var g=e.length,y=y&&b?e.map(On(y)):e;return a.core.mutate({trans:p,type:"put",keys:u,values:y,wantResults:d}).then(function(_){var v=_.numFailures,S=_.results,w=_.lastResult,_=_.failures;if(v===0)return d?S:w;throw new cr("".concat(a.name,".bulkPut(): ").concat(v," of ").concat(g," operations failed"),_)})})},mt.prototype.bulkUpdate=function(e){var n=this,s=this.core,a=e.map(function(p){return p.key}),u=e.map(function(p){return p.changes}),d=[];return this._trans("readwrite",function(p){return s.getMany({trans:p,keys:a,cache:"clone"}).then(function(b){var g=[],y=[];e.forEach(function(v,S){var w=v.key,_=v.changes,x=b[S];if(x){for(var A=0,E=Object.keys(_);A<E.length;A++){var T=E[A],z=_[T];if(T===n.schema.primKey.keyPath){if(it(z,w)!==0)throw new G.Constraint("Cannot update primary key in bulkUpdate()")}else ut(x,T,z)}d.push(S),g.push(w),y.push(x)}});var $=g.length;return s.mutate({trans:p,type:"put",keys:g,values:y,updates:{keys:a,changeSpecs:u}}).then(function(v){var S=v.numFailures,w=v.failures;if(S===0)return $;for(var _=0,x=Object.keys(w);_<x.length;_++){var A,E=x[_],T=d[Number(E)];T!=null&&(A=w[E],delete w[E],w[T]=A)}throw new cr("".concat(n.name,".bulkUpdate(): ").concat(S," of ").concat($," operations failed"),w)})})})},mt.prototype.bulkDelete=function(e){var n=this,s=e.length;return this._trans("readwrite",function(a){return n.core.mutate({trans:a,type:"delete",keys:e}).then(function(u){return Pn(n,e,u)})}).then(function(p){var u=p.numFailures,d=p.lastResult,p=p.failures;if(u===0)return d;throw new cr("".concat(n.name,".bulkDelete(): ").concat(u," of ").concat(s," operations failed"),p)})},mt);function mt(){}function Nr(e){function n(p,b){if(b){for(var g=arguments.length,y=new Array(g-1);--g;)y[g-1]=arguments[g];return s[p].subscribe.apply(null,y),e}if(typeof p=="string")return s[p]}var s={};n.addEventType=d;for(var a=1,u=arguments.length;a<u;++a)d(arguments[a]);return n;function d(p,b,g){if(typeof p!="object"){var y;b=b||Xa;var $={subscribers:[],fire:g=g||ft,subscribe:function(v){$.subscribers.indexOf(v)===-1&&($.subscribers.push(v),$.fire=b($.fire,v))},unsubscribe:function(v){$.subscribers=$.subscribers.filter(function(S){return S!==v}),$.fire=$.subscribers.reduce(b,g)}};return s[p]=n[p]=$}h(y=p).forEach(function(v){var S=y[v];if(m(S))d(v,y[v][0],y[v][1]);else{if(S!=="asap")throw new G.InvalidArgument("Invalid event config");var w=d(v,Rr,function(){for(var _=arguments.length,x=new Array(_);_--;)x[_]=arguments[_];w.subscribers.forEach(function(A){vt(function(){A.apply(null,x)})})})}})}}function qr(e,n){return W(n).from({prototype:e}),n}function br(e,n){return!(e.filter||e.algorithm||e.or)&&(n?e.justLimit:!e.replayFilter)}function No(e,n){e.filter=Ze(e.filter,n)}function qo(e,n,s){var a=e.replayFilter;e.replayFilter=a?function(){return Ze(a(),n())}:n,e.justLimit=s&&!a}function zn(e,n){if(e.isPrimKey)return n.primaryKey;var s=n.getIndexByKeyPath(e.index);if(!s)throw new G.Schema("KeyPath "+e.index+" on object store "+n.name+" is not indexed");return s}function us(e,n,s){var a=zn(e,n.schema);return n.openCursor({trans:s,values:!e.keysOnly,reverse:e.dir==="prev",unique:!!e.unique,query:{index:a,range:e.range}})}function Mn(e,n,s,a){var u=e.replayFilter?Ze(e.filter,e.replayFilter()):e.filter;if(e.or){var d={},p=function(b,g,y){var $,v;u&&!u(g,y,function(S){return g.stop(S)},function(S){return g.fail(S)})||((v=""+($=g.primaryKey))=="[object ArrayBuffer]"&&(v=""+new Uint8Array($)),P(d,v)||(d[v]=!0,n(b,g,y)))};return Promise.all([e.or._iterate(p,s),cs(us(e,a,s),e.algorithm,p,!e.keysOnly&&e.valueMapper)])}return cs(us(e,a,s),Ze(e.algorithm,u),n,!e.keysOnly&&e.valueMapper)}function cs(e,n,s,a){var u=wt(a?function(d,p,b){return s(a(d),p,b)}:s);return e.then(function(d){if(d)return d.start(function(){var p=function(){return d.continue()};n&&!n(d,function(b){return p=b},function(b){d.stop(b),p=ft},function(b){d.fail(b),p=ft})||u(d.value,d,function(b){return p=b}),p()})})}var rl=(at.prototype._read=function(e,n){var s=this._ctx;return s.error?s.table._trans(null,$t.bind(null,s.error)):s.table._trans("readonly",e).then(n)},at.prototype._write=function(e){var n=this._ctx;return n.error?n.table._trans(null,$t.bind(null,n.error)):n.table._trans("readwrite",e,"locked")},at.prototype._addAlgorithm=function(e){var n=this._ctx;n.algorithm=Ze(n.algorithm,e)},at.prototype._iterate=function(e,n){return Mn(this._ctx,e,n,this._ctx.table.core)},at.prototype.clone=function(e){var n=Object.create(this.constructor.prototype),s=Object.create(this._ctx);return e&&k(s,e),n._ctx=s,n},at.prototype.raw=function(){return this._ctx.valueMapper=null,this},at.prototype.each=function(e){var n=this._ctx;return this._read(function(s){return Mn(n,e,s,n.table.core)})},at.prototype.count=function(e){var n=this;return this._read(function(s){var a=n._ctx,u=a.table.core;if(br(a,!0))return u.count({trans:s,query:{index:zn(a,u.schema),range:a.range}}).then(function(p){return Math.min(p,a.limit)});var d=0;return Mn(a,function(){return++d,!1},s,u).then(function(){return d})}).then(e)},at.prototype.sortBy=function(e,n){var s=e.split(".").reverse(),a=s[0],u=s.length-1;function d(g,y){return y?d(g[s[y]],y-1):g[a]}var p=this._ctx.dir==="next"?1:-1;function b(g,y){return it(d(g,u),d(y,u))*p}return this.toArray(function(g){return g.sort(b)}).then(n)},at.prototype.toArray=function(e){var n=this;return this._read(function(s){var a=n._ctx;if(a.dir==="next"&&br(a,!0)&&0<a.limit){var u=a.valueMapper,d=zn(a,a.table.core.schema);return a.table.core.query({trans:s,limit:a.limit,values:!0,query:{index:d,range:a.range}}).then(function(b){return b=b.result,u?b.map(u):b})}var p=[];return Mn(a,function(b){return p.push(b)},s,a.table.core).then(function(){return p})},e)},at.prototype.offset=function(e){var n=this._ctx;return e<=0||(n.offset+=e,br(n)?qo(n,function(){var s=e;return function(a,u){return s===0||(s===1?--s:u(function(){a.advance(s),s=0}),!1)}}):qo(n,function(){var s=e;return function(){return--s<0}})),this},at.prototype.limit=function(e){return this._ctx.limit=Math.min(this._ctx.limit,e),qo(this._ctx,function(){var n=e;return function(s,a,u){return--n<=0&&a(u),0<=n}},!0),this},at.prototype.until=function(e,n){return No(this._ctx,function(s,a,u){return!e(s.value)||(a(u),n)}),this},at.prototype.first=function(e){return this.limit(1).toArray(function(n){return n[0]}).then(e)},at.prototype.last=function(e){return this.reverse().first(e)},at.prototype.filter=function(e){var n;return No(this._ctx,function(s){return e(s.value)}),(n=this._ctx).isMatch=Ze(n.isMatch,e),this},at.prototype.and=function(e){return this.filter(e)},at.prototype.or=function(e){return new this.db.WhereClause(this._ctx.table,e,this)},at.prototype.reverse=function(){return this._ctx.dir=this._ctx.dir==="prev"?"next":"prev",this._ondirectionchange&&this._ondirectionchange(this._ctx.dir),this},at.prototype.desc=function(){return this.reverse()},at.prototype.eachKey=function(e){var n=this._ctx;return n.keysOnly=!n.isMatch,this.each(function(s,a){e(a.key,a)})},at.prototype.eachUniqueKey=function(e){return this._ctx.unique="unique",this.eachKey(e)},at.prototype.eachPrimaryKey=function(e){var n=this._ctx;return n.keysOnly=!n.isMatch,this.each(function(s,a){e(a.primaryKey,a)})},at.prototype.keys=function(e){var n=this._ctx;n.keysOnly=!n.isMatch;var s=[];return this.each(function(a,u){s.push(u.key)}).then(function(){return s}).then(e)},at.prototype.primaryKeys=function(e){var n=this._ctx;if(n.dir==="next"&&br(n,!0)&&0<n.limit)return this._read(function(a){var u=zn(n,n.table.core.schema);return n.table.core.query({trans:a,values:!1,limit:n.limit,query:{index:u,range:n.range}})}).then(function(a){return a.result}).then(e);n.keysOnly=!n.isMatch;var s=[];return this.each(function(a,u){s.push(u.primaryKey)}).then(function(){return s}).then(e)},at.prototype.uniqueKeys=function(e){return this._ctx.unique="unique",this.keys(e)},at.prototype.firstKey=function(e){return this.limit(1).keys(function(n){return n[0]}).then(e)},at.prototype.lastKey=function(e){return this.reverse().firstKey(e)},at.prototype.distinct=function(){var e=this._ctx,e=e.index&&e.table.schema.idxByName[e.index];if(!e||!e.multi)return this;var n={};return No(this._ctx,function(u){var a=u.primaryKey.toString(),u=P(n,a);return n[a]=!0,!u}),this},at.prototype.modify=function(e){var n=this,s=this._ctx;return this._write(function(a){var u=typeof e=="function"?e:function(x){return as(x,e)},d=s.table.core,y=d.schema.primaryKey,p=y.outbound,b=y.extractKey,g=200,y=n.db._options.modifyChunkSize;y&&(g=typeof y=="object"?y[d.name]||y["*"]||200:y);function $(x,T){var E=T.failures,T=T.numFailures;S+=x-T;for(var z=0,M=h(E);z<M.length;z++){var I=M[z];v.push(E[I])}}var v=[],S=0,w=[],_=e===ds;return n.clone().primaryKeys().then(function(x){function A(T){var z=Math.min(g,x.length-T),M=x.slice(T,T+z);return(_?Promise.resolve([]):d.getMany({trans:a,keys:M,cache:"immutable"})).then(function(I){var q=[],B=[],L=p?[]:null,j=_?M:[];if(!_)for(var V=0;V<z;++V){var H=I[V],Z={value:It(H),primKey:x[T+V]};u.call(Z,Z.value,Z)!==!1&&(Z.value==null?j.push(x[T+V]):p||it(b(H),b(Z.value))===0?(B.push(Z.value),p&&L.push(x[T+V])):(j.push(x[T+V]),q.push(Z.value)))}return Promise.resolve(0<q.length&&d.mutate({trans:a,type:"add",values:q}).then(function(et){for(var nt in et.failures)j.splice(parseInt(nt),1);$(q.length,et)})).then(function(){return(0<B.length||E&&typeof e=="object")&&d.mutate({trans:a,type:"put",keys:L,values:B,criteria:E,changeSpec:typeof e!="function"&&e,isAdditionalChunk:0<T}).then(function(et){return $(B.length,et)})}).then(function(){return(0<j.length||E&&_)&&d.mutate({trans:a,type:"delete",keys:j,criteria:E,isAdditionalChunk:0<T}).then(function(et){return Pn(s.table,j,et)}).then(function(et){return $(j.length,et)})}).then(function(){return x.length>T+z&&A(T+g)})})}var E=br(s)&&s.limit===1/0&&(typeof e!="function"||_)&&{index:s.index,range:s.range};return A(0).then(function(){if(0<v.length)throw new yn("Error modifying one or more objects",v,S,w);return x.length})})})},at.prototype.delete=function(){var e=this._ctx,n=e.range;return!br(e)||e.table.schema.yProps||!e.isPrimKey&&n.type!==3?this.modify(ds):this._write(function(s){var a=e.table.core.schema.primaryKey,u=n;return e.table.core.count({trans:s,query:{index:a,range:u}}).then(function(d){return e.table.core.mutate({trans:s,type:"deleteRange",range:u}).then(function(g){var b=g.failures,g=g.numFailures;if(g)throw new yn("Could not delete some values",Object.keys(b).map(function(y){return b[y]}),d-g);return d-g})})})},at);function at(){}var ds=function(e,n){return n.value=null};function nl(e,n){return e<n?-1:e===n?0:1}function ol(e,n){return n<e?-1:e===n?0:1}function Yt(e,n,s){return e=e instanceof ps?new e.Collection(e):e,e._ctx.error=new(s||TypeError)(n),e}function mr(e){return new e.Collection(e,function(){return hs("")}).limit(0)}function Dn(e,n,s,a){var u,d,p,b,g,y,$,v=s.length;if(!s.every(function(_){return typeof _=="string"}))return Yt(e,es);function S(_){u=_==="next"?function(A){return A.toUpperCase()}:function(A){return A.toLowerCase()},d=_==="next"?function(A){return A.toLowerCase()}:function(A){return A.toUpperCase()},p=_==="next"?nl:ol;var x=s.map(function(A){return{lower:d(A),upper:u(A)}}).sort(function(A,E){return p(A.lower,E.lower)});b=x.map(function(A){return A.upper}),g=x.map(function(A){return A.lower}),$=(y=_)==="next"?"":a}S("next"),e=new e.Collection(e,function(){return ze(b[0],g[v-1]+a)}),e._ondirectionchange=function(_){S(_)};var w=0;return e._addAlgorithm(function(_,x,A){var E=_.key;if(typeof E!="string")return!1;var T=d(E);if(n(T,g,w))return!0;for(var z=null,M=w;M<v;++M){var I=(function(q,B,L,j,V,H){for(var Z=Math.min(q.length,j.length),et=-1,nt=0;nt<Z;++nt){var Xt=B[nt];if(Xt!==j[nt])return V(q[nt],L[nt])<0?q.substr(0,nt)+L[nt]+L.substr(nt+1):V(q[nt],j[nt])<0?q.substr(0,nt)+j[nt]+L.substr(nt+1):0<=et?q.substr(0,et)+B[et]+L.substr(et+1):null;V(q[nt],Xt)<0&&(et=nt)}return Z<j.length&&H==="next"?q+L.substr(q.length):Z<q.length&&H==="prev"?q.substr(0,L.length):et<0?null:q.substr(0,et)+j[et]+L.substr(et+1)})(E,T,b[M],g[M],p,y);I===null&&z===null?w=M+1:(z===null||0<p(z,I))&&(z=I)}return x(z!==null?function(){_.continue(z+$)}:A),!1}),e}function ze(e,n,s,a){return{type:2,lower:e,upper:n,lowerOpen:s,upperOpen:a}}function hs(e){return{type:1,lower:e,upper:e}}var ps=(Object.defineProperty(Ot.prototype,"Collection",{get:function(){return this._ctx.table.db.Collection},enumerable:!1,configurable:!0}),Ot.prototype.between=function(e,n,s,a){s=s!==!1,a=a===!0;try{return 0<this._cmp(e,n)||this._cmp(e,n)===0&&(s||a)&&(!s||!a)?mr(this):new this.Collection(this,function(){return ze(e,n,!s,!a)})}catch{return Yt(this,we)}},Ot.prototype.equals=function(e){return e==null?Yt(this,we):new this.Collection(this,function(){return hs(e)})},Ot.prototype.above=function(e){return e==null?Yt(this,we):new this.Collection(this,function(){return ze(e,void 0,!0)})},Ot.prototype.aboveOrEqual=function(e){return e==null?Yt(this,we):new this.Collection(this,function(){return ze(e,void 0,!1)})},Ot.prototype.below=function(e){return e==null?Yt(this,we):new this.Collection(this,function(){return ze(void 0,e,!1,!0)})},Ot.prototype.belowOrEqual=function(e){return e==null?Yt(this,we):new this.Collection(this,function(){return ze(void 0,e)})},Ot.prototype.startsWith=function(e){return typeof e!="string"?Yt(this,es):this.between(e,e+Qe,!0,!0)},Ot.prototype.startsWithIgnoreCase=function(e){return e===""?this.startsWith(e):Dn(this,function(n,s){return n.indexOf(s[0])===0},[e],Qe)},Ot.prototype.equalsIgnoreCase=function(e){return Dn(this,function(n,s){return n===s[0]},[e],"")},Ot.prototype.anyOfIgnoreCase=function(){var e=se.apply(Kt,arguments);return e.length===0?mr(this):Dn(this,function(n,s){return s.indexOf(n)!==-1},e,"")},Ot.prototype.startsWithAnyOfIgnoreCase=function(){var e=se.apply(Kt,arguments);return e.length===0?mr(this):Dn(this,function(n,s){return s.some(function(a){return n.indexOf(a)===0})},e,Qe)},Ot.prototype.anyOf=function(){var e=this,n=se.apply(Kt,arguments),s=this._cmp;try{n.sort(s)}catch{return Yt(this,we)}if(n.length===0)return mr(this);var a=new this.Collection(this,function(){return ze(n[0],n[n.length-1])});a._ondirectionchange=function(d){s=d==="next"?e._ascending:e._descending,n.sort(s)};var u=0;return a._addAlgorithm(function(d,p,b){for(var g=d.key;0<s(g,n[u]);)if(++u===n.length)return p(b),!1;return s(g,n[u])===0||(p(function(){d.continue(n[u])}),!1)}),a},Ot.prototype.notEqual=function(e){return this.inAnyRange([[-1/0,e],[e,this.db._maxKey]],{includeLowers:!1,includeUppers:!1})},Ot.prototype.noneOf=function(){var e=se.apply(Kt,arguments);if(e.length===0)return new this.Collection(this);try{e.sort(this._ascending)}catch{return Yt(this,we)}var n=e.reduce(function(s,a){return s?s.concat([[s[s.length-1][1],a]]):[[-1/0,a]]},null);return n.push([e[e.length-1],this.db._maxKey]),this.inAnyRange(n,{includeLowers:!1,includeUppers:!1})},Ot.prototype.inAnyRange=function(E,n){var s=this,a=this._cmp,u=this._ascending,d=this._descending,p=this._min,b=this._max;if(E.length===0)return mr(this);if(!E.every(function(T){return T[0]!==void 0&&T[1]!==void 0&&u(T[0],T[1])<=0}))return Yt(this,"First argument to inAnyRange() must be an Array of two-value Arrays [lower,upper] where upper must not be lower than lower",G.InvalidArgument);var g=!n||n.includeLowers!==!1,y=n&&n.includeUppers===!0,$,v=u;function S(T,z){return v(T[0],z[0])}try{($=E.reduce(function(T,z){for(var M=0,I=T.length;M<I;++M){var q=T[M];if(a(z[0],q[1])<0&&0<a(z[1],q[0])){q[0]=p(q[0],z[0]),q[1]=b(q[1],z[1]);break}}return M===I&&T.push(z),T},[])).sort(S)}catch{return Yt(this,we)}var w=0,_=y?function(T){return 0<u(T,$[w][1])}:function(T){return 0<=u(T,$[w][1])},x=g?function(T){return 0<d(T,$[w][0])}:function(T){return 0<=d(T,$[w][0])},A=_,E=new this.Collection(this,function(){return ze($[0][0],$[$.length-1][1],!g,!y)});return E._ondirectionchange=function(T){v=T==="next"?(A=_,u):(A=x,d),$.sort(S)},E._addAlgorithm(function(T,z,M){for(var I,q=T.key;A(q);)if(++w===$.length)return z(M),!1;return!_(I=q)&&!x(I)||(s._cmp(q,$[w][1])===0||s._cmp(q,$[w][0])===0||z(function(){v===u?T.continue($[w][0]):T.continue($[w][1])}),!1)}),E},Ot.prototype.startsWithAnyOf=function(){var e=se.apply(Kt,arguments);return e.every(function(n){return typeof n=="string"})?e.length===0?mr(this):this.inAnyRange(e.map(function(n){return[n,n+Qe]})):Yt(this,"startsWithAnyOf() only works with strings")},Ot);function Ot(){}function pe(e){return wt(function(n){return jr(n),e(n.target.error),!1})}function jr(e){e.stopPropagation&&e.stopPropagation(),e.preventDefault&&e.preventDefault()}var Kr="storagemutated",jo="x-storagemutated-1",Me=Nr(null,Kr),il=(fe.prototype._lock=function(){return yt(!U.global),++this._reculock,this._reculock!==1||U.global||(U.lockOwnerFor=this),this},fe.prototype._unlock=function(){if(yt(!U.global),--this._reculock==0)for(U.global||(U.lockOwnerFor=null);0<this._blockedFuncs.length&&!this._locked();){var e=this._blockedFuncs.shift();try{Xe(e[1],e[0])}catch{}}return this},fe.prototype._locked=function(){return this._reculock&&U.lockOwnerFor!==this},fe.prototype.create=function(e){var n=this;if(!this.mode)return this;var s=this.db.idbdb,a=this.db._state.dbOpenError;if(yt(!this.idbtrans),!e&&!s)switch(a&&a.name){case"DatabaseClosedError":throw new G.DatabaseClosed(a);case"MissingAPIError":throw new G.MissingAPI(a.message,a);default:throw new G.OpenFailed(a)}if(!this.active)throw new G.TransactionInactive;return yt(this._completion._state===null),(e=this.idbtrans=e||(this.db.core||s).transaction(this.storeNames,this.mode,{durability:this.chromeTransactionDurability})).onerror=wt(function(u){jr(u),n._reject(e.error)}),e.onabort=wt(function(u){jr(u),n.active&&n._reject(new G.Abort(e.error)),n.active=!1,n.on("abort").fire(u)}),e.oncomplete=wt(function(){n.active=!1,n._resolve(),"mutatedParts"in e&&Me.storagemutated.fire(e.mutatedParts)}),this},fe.prototype._promise=function(e,n,s){var a=this;if(e==="readwrite"&&this.mode!=="readwrite")return $t(new G.ReadOnly("Transaction is readonly"));if(!this.active)return $t(new G.TransactionInactive);if(this._locked())return new K(function(d,p){a._blockedFuncs.push([function(){a._promise(e,n,s).then(d,p)},U])});if(s)return Te(function(){var d=new K(function(p,b){a._lock();var g=n(p,b,a);g&&g.then&&g.then(p,b)});return d.finally(function(){return a._unlock()}),d._lib=!0,d});var u=new K(function(d,p){var b=n(d,p,a);b&&b.then&&b.then(d,p)});return u._lib=!0,u},fe.prototype._root=function(){return this.parent?this.parent._root():this},fe.prototype.waitFor=function(e){var n,s=this._root(),a=K.resolve(e);s._waitingFor?s._waitingFor=s._waitingFor.then(function(){return a}):(s._waitingFor=a,s._waitingQueue=[],n=s.idbtrans.objectStore(s.storeNames[0]),(function d(){for(++s._spinCount;s._waitingQueue.length;)s._waitingQueue.shift()();s._waitingFor&&(n.get(-1/0).onsuccess=d)})());var u=s._waitingFor;return new K(function(d,p){a.then(function(b){return s._waitingQueue.push(wt(d.bind(null,b)))},function(b){return s._waitingQueue.push(wt(p.bind(null,b)))}).finally(function(){s._waitingFor===u&&(s._waitingFor=null)})})},fe.prototype.abort=function(){this.active&&(this.active=!1,this.idbtrans&&this.idbtrans.abort(),this._reject(new G.Abort))},fe.prototype.table=function(e){var n=this._memoizedTables||(this._memoizedTables={});if(P(n,e))return n[e];var s=this.schema[e];if(!s)throw new G.NotFound("Table "+e+" not part of transaction");return s=new this.db.Table(e,s,this),s.core=this.db.core.table(e),n[e]=s},fe);function fe(){}function Ko(e,n,s,a,u,d,p,b){return{name:e,keyPath:n,unique:s,multi:a,auto:u,compound:d,src:(s&&!p?"&":"")+(a?"*":"")+(u?"++":"")+fs(n),type:b}}function fs(e){return typeof e=="string"?e:e?"["+[].join.call(e,"+")+"]":""}function Ho(e,n,s){return{name:e,primKey:n,indexes:s,mappedClass:null,idxByName:(a=function(u){return[u.name,u]},s.reduce(function(u,d,p){return p=a(d,p),p&&(u[p[0]]=p[1]),u},{}))};var a}var Hr=function(e){try{return e.only([[]]),Hr=function(){return[[]]},[[]]}catch{return Hr=function(){return Qe},Qe}};function Uo(e){return e==null?function(){}:typeof e=="string"?(n=e).split(".").length===1?function(s){return s[n]}:function(s){return Ct(s,n)}:function(s){return Ct(s,e)};var n}function bs(e){return[].slice.call(e)}var sl=0;function Ur(e){return e==null?":id":typeof e=="string"?e:"[".concat(e.join("+"),"]")}function al(e,n,g){function a(A){if(A.type===3)return null;if(A.type===4)throw new Error("Cannot convert never type to IDBKeyRange");var w=A.lower,_=A.upper,x=A.lowerOpen,A=A.upperOpen;return w===void 0?_===void 0?null:n.upperBound(_,!!A):_===void 0?n.lowerBound(w,!!x):n.bound(w,_,!!x,!!A)}function u(S){var w,_=S.name;return{name:_,schema:S,mutate:function(x){var A=x.trans,E=x.type,T=x.keys,z=x.values,M=x.range;return new Promise(function(I,q){I=wt(I);var B=A.objectStore(_),L=B.keyPath==null,j=E==="put"||E==="add";if(!j&&E!=="delete"&&E!=="deleteRange")throw new Error("Invalid operation type: "+E);var V,H=(T||z||{length:1}).length;if(T&&z&&T.length!==z.length)throw new Error("Given keys array must have same length as given values array.");if(H===0)return I({numFailures:0,failures:{},results:[],lastResult:void 0});function Z(Ht){++Xt,jr(Ht)}var et=[],nt=[],Xt=0;if(E==="deleteRange"){if(M.type===4)return I({numFailures:Xt,failures:nt,results:[],lastResult:void 0});M.type===3?et.push(V=B.clear()):et.push(V=B.delete(a(M)))}else{var L=j?L?[z,T]:[z,null]:[T,null],Q=L[0],Ft=L[1];if(j)for(var Vt=0;Vt<H;++Vt)et.push(V=Ft&&Ft[Vt]!==void 0?B[E](Q[Vt],Ft[Vt]):B[E](Q[Vt])),V.onerror=Z;else for(Vt=0;Vt<H;++Vt)et.push(V=B[E](Q[Vt])),V.onerror=Z}function Un(Ht){Ht=Ht.target.result,et.forEach(function(er,ci){return er.error!=null&&(nt[ci]=er.error)}),I({numFailures:Xt,failures:nt,results:E==="delete"?T:et.map(function(er){return er.result}),lastResult:Ht})}V.onerror=function(Ht){Z(Ht),Un(Ht)},V.onsuccess=Un})},getMany:function(x){var A=x.trans,E=x.keys;return new Promise(function(T,z){T=wt(T);for(var M,I=A.objectStore(_),q=E.length,B=new Array(q),L=0,j=0,V=function(et){et=et.target,B[et._pos]=et.result,++j===L&&T(B)},H=pe(z),Z=0;Z<q;++Z)E[Z]!=null&&((M=I.get(E[Z]))._pos=Z,M.onsuccess=V,M.onerror=H,++L);L===0&&T(B)})},get:function(x){var A=x.trans,E=x.key;return new Promise(function(T,z){T=wt(T);var M=A.objectStore(_).get(E);M.onsuccess=function(I){return T(I.target.result)},M.onerror=pe(z)})},query:(w=y,function(x){return new Promise(function(A,E){A=wt(A);var T,z,M,L=x.trans,I=x.values,q=x.limit,V=x.query,B=q===1/0?void 0:q,j=V.index,V=V.range,L=L.objectStore(_),j=j.isPrimaryKey?L:L.index(j.name),V=a(V);if(q===0)return A({result:[]});w?((B=I?j.getAll(V,B):j.getAllKeys(V,B)).onsuccess=function(H){return A({result:H.target.result})},B.onerror=pe(E)):(T=0,z=!I&&"openKeyCursor"in j?j.openKeyCursor(V):j.openCursor(V),M=[],z.onsuccess=function(H){var Z=z.result;return Z?(M.push(I?Z.value:Z.primaryKey),++T===q?A({result:M}):void Z.continue()):A({result:M})},z.onerror=pe(E))})}),openCursor:function(x){var A=x.trans,E=x.values,T=x.query,z=x.reverse,M=x.unique;return new Promise(function(I,q){I=wt(I);var j=T.index,B=T.range,L=A.objectStore(_),L=j.isPrimaryKey?L:L.index(j.name),j=z?M?"prevunique":"prev":M?"nextunique":"next",V=!E&&"openKeyCursor"in L?L.openKeyCursor(a(B),j):L.openCursor(a(B),j);V.onerror=pe(q),V.onsuccess=wt(function(H){var Z,et,nt,Xt,Q=V.result;Q?(Q.___id=++sl,Q.done=!1,Z=Q.continue.bind(Q),et=(et=Q.continuePrimaryKey)&&et.bind(Q),nt=Q.advance.bind(Q),Xt=function(){throw new Error("Cursor not stopped")},Q.trans=A,Q.stop=Q.continue=Q.continuePrimaryKey=Q.advance=function(){throw new Error("Cursor not started")},Q.fail=wt(q),Q.next=function(){var Ft=this,Vt=1;return this.start(function(){return Vt--?Ft.continue():Ft.stop()}).then(function(){return Ft})},Q.start=function(Ft){function Vt(){if(V.result)try{Ft()}catch(Ht){Q.fail(Ht)}else Q.done=!0,Q.start=function(){throw new Error("Cursor behind last entry")},Q.stop()}var Un=new Promise(function(Ht,er){Ht=wt(Ht),V.onerror=pe(er),Q.fail=er,Q.stop=function(ci){Q.stop=Q.continue=Q.continuePrimaryKey=Q.advance=Xt,Ht(ci)}});return V.onsuccess=wt(function(Ht){V.onsuccess=Vt,Vt()}),Q.continue=Z,Q.continuePrimaryKey=et,Q.advance=nt,Vt(),Un},I(Q)):I(null)},q)})},count:function(x){var A=x.query,E=x.trans,T=A.index,z=A.range;return new Promise(function(M,I){var q=E.objectStore(_),B=T.isPrimaryKey?q:q.index(T.name),q=a(z),B=q?B.count(q):B.count();B.onsuccess=wt(function(L){return M(L.target.result)}),B.onerror=pe(I)})}}}var d,p,b,$=(p=g,b=bs((d=e).objectStoreNames),{schema:{name:d.name,tables:b.map(function(S){return p.objectStore(S)}).map(function(S){var w=S.keyPath,A=S.autoIncrement,_=m(w),x={},A={name:S.name,primaryKey:{name:null,isPrimaryKey:!0,outbound:w==null,compound:_,keyPath:w,autoIncrement:A,unique:!0,extractKey:Uo(w)},indexes:bs(S.indexNames).map(function(E){return S.index(E)}).map(function(M){var T=M.name,z=M.unique,I=M.multiEntry,M=M.keyPath,I={name:T,compound:m(M),keyPath:M,unique:z,multiEntry:I,extractKey:Uo(M)};return x[Ur(M)]=I}),getIndexByKeyPath:function(E){return x[Ur(E)]}};return x[":id"]=A.primaryKey,w!=null&&(x[Ur(w)]=A.primaryKey),A})},hasGetAll:0<b.length&&"getAll"in p.objectStore(b[0])&&!(typeof navigator<"u"&&/Safari/.test(navigator.userAgent)&&!/(Chrome\/|Edge\/)/.test(navigator.userAgent)&&[].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1]<604)}),g=$.schema,y=$.hasGetAll,$=g.tables.map(u),v={};return $.forEach(function(S){return v[S.name]=S}),{stack:"dbcore",transaction:e.transaction.bind(e),table:function(S){if(!v[S])throw new Error("Table '".concat(S,"' not found"));return v[S]},MIN_KEY:-1/0,MAX_KEY:Hr(n),schema:g}}function ll(e,n,s,a){var u=s.IDBKeyRange;return s.indexedDB,{dbcore:(a=al(n,u,a),e.dbcore.reduce(function(d,p){return p=p.create,i(i({},d),p(d))},a))}}function Rn(e,a){var s=a.db,a=ll(e._middlewares,s,e._deps,a);e.core=a.dbcore,e.tables.forEach(function(u){var d=u.name;e.core.schema.tables.some(function(p){return p.name===d})&&(u.core=e.core.table(d),e[d]instanceof e.Table&&(e[d].core=u.core))})}function Bn(e,n,s,a){s.forEach(function(u){var d=a[u];n.forEach(function(p){var b=(function g(y,$){return tt(y,$)||(y=O(y))&&g(y,$)})(p,u);(!b||"value"in b&&b.value===void 0)&&(p===e.Transaction.prototype||p instanceof e.Transaction?N(p,u,{get:function(){return this.table(u)},set:function(g){R(this,u,{value:g,writable:!0,configurable:!0,enumerable:!0})}}):p[u]=new e.Table(u,d))})})}function Wo(e,n){n.forEach(function(s){for(var a in s)s[a]instanceof e.Table&&delete s[a]})}function ul(e,n){return e._cfg.version-n._cfg.version}function cl(e,n,s,a){var u=e._dbSchema;s.objectStoreNames.contains("$meta")&&!u.$meta&&(u.$meta=Ho("$meta",vs("")[0],[]),e._storeNames.push("$meta"));var d=e._createTransaction("readwrite",e._storeNames,u);d.create(s),d._completion.catch(a);var p=d._reject.bind(d),b=U.transless||U;Te(function(){return U.trans=d,U.transless=b,n!==0?(Rn(e,s),y=n,((g=d).storeNames.includes("$meta")?g.table("$meta").get("version").then(function($){return $??y}):K.resolve(y)).then(function($){return S=$,w=d,_=s,x=[],$=(v=e)._versions,A=v._dbSchema=Ln(0,v.idbdb,_),($=$.filter(function(E){return E._cfg.version>=S})).length!==0?($.forEach(function(E){x.push(function(){var T=A,z=E._cfg.dbschema;Fn(v,T,_),Fn(v,z,_),A=v._dbSchema=z;var M=Go(T,z);M.add.forEach(function(j){Yo(_,j[0],j[1].primKey,j[1].indexes)}),M.change.forEach(function(j){if(j.recreate)throw new G.Upgrade("Not yet support for changing primary key");var V=_.objectStore(j.name);j.add.forEach(function(H){return In(V,H)}),j.change.forEach(function(H){V.deleteIndex(H.name),In(V,H)}),j.del.forEach(function(H){return V.deleteIndex(H)})});var I=E._cfg.contentUpgrade;if(I&&E._cfg.version>S){Rn(v,_),w._memoizedTables={};var q=te(z);M.del.forEach(function(j){q[j]=T[j]}),Wo(v,[v.Transaction.prototype]),Bn(v,[v.Transaction.prototype],h(q),q),w.schema=q;var B,L=Eo(I);return L&&pr(),M=K.follow(function(){var j;(B=I(w))&&L&&(j=Oe.bind(null,null),B.then(j,j))}),B&&typeof B.then=="function"?K.resolve(B):M.then(function(){return B})}}),x.push(function(T){var z,M,I=E._cfg.dbschema;z=I,M=T,[].slice.call(M.db.objectStoreNames).forEach(function(q){return z[q]==null&&M.db.deleteObjectStore(q)}),Wo(v,[v.Transaction.prototype]),Bn(v,[v.Transaction.prototype],v._storeNames,v._dbSchema),w.schema=v._dbSchema}),x.push(function(T){v.idbdb.objectStoreNames.contains("$meta")&&(Math.ceil(v.idbdb.version/10)===E._cfg.version?(v.idbdb.deleteObjectStore("$meta"),delete v._dbSchema.$meta,v._storeNames=v._storeNames.filter(function(z){return z!=="$meta"})):T.objectStore("$meta").put(E._cfg.version,"version"))})}),(function E(){return x.length?K.resolve(x.shift()(w.idbtrans)).then(E):K.resolve()})().then(function(){ms(A,_)})):K.resolve();var v,S,w,_,x,A}).catch(p)):(h(u).forEach(function($){Yo(s,$,u[$].primKey,u[$].indexes)}),Rn(e,s),void K.follow(function(){return e.on.populate.fire(d)}).catch(p));var g,y})}function dl(e,n){ms(e._dbSchema,n),n.db.version%10!=0||n.objectStoreNames.contains("$meta")||n.db.createObjectStore("$meta").add(Math.ceil(n.db.version/10-1),"version");var s=Ln(0,e.idbdb,n);Fn(e,e._dbSchema,n);for(var a=0,u=Go(s,e._dbSchema).change;a<u.length;a++){var d=(function(p){if(p.change.length||p.recreate)return console.warn("Unable to patch indexes of table ".concat(p.name," because it has changes on the type of index or primary key.")),{value:void 0};var b=n.objectStore(p.name);p.add.forEach(function(g){he&&console.debug("Dexie upgrade patch: Creating missing index ".concat(p.name,".").concat(g.src)),In(b,g)})})(u[a]);if(typeof d=="object")return d.value}}function Go(e,n){var s,a={del:[],add:[],change:[]};for(s in e)n[s]||a.del.push(s);for(s in n){var u=e[s],d=n[s];if(u){var p={name:s,def:d,recreate:!1,del:[],add:[],change:[]};if(""+(u.primKey.keyPath||"")!=""+(d.primKey.keyPath||"")||u.primKey.auto!==d.primKey.auto)p.recreate=!0,a.change.push(p);else{var b=u.idxByName,g=d.idxByName,y=void 0;for(y in b)g[y]||p.del.push(y);for(y in g){var $=b[y],v=g[y];$?$.src!==v.src&&p.change.push(v):p.add.push(v)}(0<p.del.length||0<p.add.length||0<p.change.length)&&a.change.push(p)}}else a.add.push([s,d])}return a}function Yo(e,n,s,a){var u=e.db.createObjectStore(n,s.keyPath?{keyPath:s.keyPath,autoIncrement:s.auto}:{autoIncrement:s.auto});return a.forEach(function(d){return In(u,d)}),u}function ms(e,n){h(e).forEach(function(s){n.db.objectStoreNames.contains(s)||(he&&console.debug("Dexie: Creating missing table",s),Yo(n,s,e[s].primKey,e[s].indexes))})}function In(e,n){e.createIndex(n.name,n.keyPath,{unique:n.unique,multiEntry:n.multi})}function Ln(e,n,s){var a={};return ot(n.objectStoreNames,0).forEach(function(u){for(var d=s.objectStore(u),p=Ko(fs(y=d.keyPath),y||"",!0,!1,!!d.autoIncrement,y&&typeof y!="string",!0),b=[],g=0;g<d.indexNames.length;++g){var $=d.index(d.indexNames[g]),y=$.keyPath,$=Ko($.name,y,!!$.unique,!!$.multiEntry,!1,y&&typeof y!="string",!1);b.push($)}a[u]=Ho(u,p,b)}),a}function Fn(e,n,s){for(var a=s.db.objectStoreNames,u=0;u<a.length;++u){var d=a[u],p=s.objectStore(d);e._hasGetAll="getAll"in p;for(var b=0;b<p.indexNames.length;++b){var g=p.indexNames[b],y=p.index(g).keyPath,$=typeof y=="string"?y:"["+ot(y).join("+")+"]";!n[d]||(y=n[d].idxByName[$])&&(y.name=g,delete n[d].idxByName[$],n[d].idxByName[g]=y)}}typeof navigator<"u"&&/Safari/.test(navigator.userAgent)&&!/(Chrome\/|Edge\/)/.test(navigator.userAgent)&&c.WorkerGlobalScope&&c instanceof c.WorkerGlobalScope&&[].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1]<604&&(e._hasGetAll=!1)}function vs(e){return e.split(",").map(function(n,s){var d=n.split(":"),a=(u=d[1])===null||u===void 0?void 0:u.trim(),u=(n=d[0].trim()).replace(/([&*]|\+\+)/g,""),d=/^\[/.test(u)?u.match(/^\[(.*)\]$/)[1].split("+"):u;return Ko(u,d||null,/\&/.test(n),/\*/.test(n),/\+\+/.test(n),m(d),s===0,a)})}var hl=(vr.prototype._createTableSchema=Ho,vr.prototype._parseIndexSyntax=vs,vr.prototype._parseStoresSpec=function(e,n){var s=this;h(e).forEach(function(a){if(e[a]!==null){var u=s._parseIndexSyntax(e[a]),d=u.shift();if(!d)throw new G.Schema("Invalid schema for table "+a+": "+e[a]);if(d.unique=!0,d.multi)throw new G.Schema("Primary key cannot be multiEntry*");u.forEach(function(p){if(p.auto)throw new G.Schema("Only primary key can be marked as autoIncrement (++)");if(!p.keyPath)throw new G.Schema("Index must have a name and cannot be an empty string")}),u=s._createTableSchema(a,d,u),n[a]=u}})},vr.prototype.stores=function(s){var n=this.db;this._cfg.storesSource=this._cfg.storesSource?k(this._cfg.storesSource,s):s;var s=n._versions,a={},u={};return s.forEach(function(d){k(a,d._cfg.storesSource),u=d._cfg.dbschema={},d._parseStoresSpec(a,u)}),n._dbSchema=u,Wo(n,[n._allTables,n,n.Transaction.prototype]),Bn(n,[n._allTables,n,n.Transaction.prototype,this._cfg.tables],h(u),u),n._storeNames=h(u),this},vr.prototype.upgrade=function(e){return this._cfg.contentUpgrade=Oo(this._cfg.contentUpgrade||ft,e),this},vr);function vr(){}function Xo(e,n){var s=e._dbNamesDB;return s||(s=e._dbNamesDB=new _e(Tn,{addons:[],indexedDB:e,IDBKeyRange:n})).version(1).stores({dbnames:"name"}),s.table("dbnames")}function Qo(e){return e&&typeof e.databases=="function"}function Zo(e){return Te(function(){return U.letThrough=!0,e()})}function Jo(e){return!("from"in e)}var Lt=function(e,n){if(!this){var s=new Lt;return e&&"d"in e&&k(s,e),s}k(this,arguments.length?{d:1,from:e,to:1<arguments.length?n:e}:{d:0})};function Wr(e,n,s){var a=it(n,s);if(!isNaN(a)){if(0<a)throw RangeError();if(Jo(e))return k(e,{from:n,to:s,d:1});var u=e.l,a=e.r;if(it(s,e.from)<0)return u?Wr(u,n,s):e.l={from:n,to:s,d:1,l:null,r:null},ys(e);if(0<it(n,e.to))return a?Wr(a,n,s):e.r={from:n,to:s,d:1,l:null,r:null},ys(e);it(n,e.from)<0&&(e.from=n,e.l=null,e.d=a?a.d+1:1),0<it(s,e.to)&&(e.to=s,e.r=null,e.d=e.l?e.l.d+1:1),s=!e.r,u&&!e.l&&Gr(e,u),a&&s&&Gr(e,a)}}function Gr(e,n){Jo(n)||(function s(a,g){var d=g.from,p=g.to,b=g.l,g=g.r;Wr(a,d,p),b&&s(a,b),g&&s(a,g)})(e,n)}function gs(e,n){var s=Vn(n),a=s.next();if(a.done)return!1;for(var u=a.value,d=Vn(e),p=d.next(u.from),b=p.value;!a.done&&!p.done;){if(it(b.from,u.to)<=0&&0<=it(b.to,u.from))return!0;it(u.from,b.from)<0?u=(a=s.next(b.from)).value:b=(p=d.next(u.from)).value}return!1}function Vn(e){var n=Jo(e)?null:{s:0,n:e};return{next:function(s){for(var a=0<arguments.length;n;)switch(n.s){case 0:if(n.s=1,a)for(;n.n.l&&it(s,n.n.from)<0;)n={up:n,n:n.n.l,s:1};else for(;n.n.l;)n={up:n,n:n.n.l,s:1};case 1:if(n.s=2,!a||it(s,n.n.to)<=0)return{value:n.n,done:!1};case 2:if(n.n.r){n.s=3,n={up:n,n:n.n.r,s:0};continue}case 3:n=n.up}return{done:!0}}}}function ys(e){var n,s,a=(((n=e.r)===null||n===void 0?void 0:n.d)||0)-(((s=e.l)===null||s===void 0?void 0:s.d)||0),u=1<a?"r":a<-1?"l":"";u&&(n=u=="r"?"l":"r",s=i({},e),a=e[u],e.from=a.from,e.to=a.to,e[u]=a[u],s[u]=a[n],(e[n]=s).d=ws(s)),e.d=ws(e)}function ws(s){var n=s.r,s=s.l;return(n?s?Math.max(n.d,s.d):n.d:s?s.d:0)+1}function Nn(e,n){return h(n).forEach(function(s){e[s]?Gr(e[s],n[s]):e[s]=(function a(u){var d,p,b={};for(d in u)P(u,d)&&(p=u[d],b[d]=!p||typeof p!="object"||oe.has(p.constructor)?p:a(p));return b})(n[s])}),e}function ti(e,n){return e.all||n.all||Object.keys(e).some(function(s){return n[s]&&gs(n[s],e[s])})}F(Lt.prototype,((re={add:function(e){return Gr(this,e),this},addKey:function(e){return Wr(this,e,e),this},addKeys:function(e){var n=this;return e.forEach(function(s){return Wr(n,s,s)}),this},hasKey:function(e){var n=Vn(this).next(e).value;return n&&it(n.from,e)<=0&&0<=it(n.to,e)}})[Wt]=function(){return Vn(this)},re));var Je={},ei={},ri=!1;function qn(e){Nn(ei,e),ri||(ri=!0,setTimeout(function(){ri=!1,ni(ei,!(ei={}))},0))}function ni(e,n){n===void 0&&(n=!1);var s=new Set;if(e.all)for(var a=0,u=Object.values(Je);a<u.length;a++)_s(p=u[a],e,s,n);else for(var d in e){var p,b=/^idb\:\/\/(.*)\/(.*)\//.exec(d);b&&(d=b[1],b=b[2],(p=Je["idb://".concat(d,"/").concat(b)])&&_s(p,e,s,n))}s.forEach(function(g){return g()})}function _s(e,n,s,a){for(var u=[],d=0,p=Object.entries(e.queries.query);d<p.length;d++){for(var b=p[d],g=b[0],y=[],$=0,v=b[1];$<v.length;$++){var S=v[$];ti(n,S.obsSet)?S.subscribers.forEach(function(A){return s.add(A)}):a&&y.push(S)}a&&u.push([g,y])}if(a)for(var w=0,_=u;w<_.length;w++){var x=_[w],g=x[0],y=x[1];e.queries.query[g]=y}}function pl(e){var n=e._state,s=e._deps.indexedDB;if(n.isBeingOpened||e.idbdb)return n.dbReadyPromise.then(function(){return n.dbOpenError?$t(n.dbOpenError):e});n.isBeingOpened=!0,n.dbOpenError=null,n.openComplete=!1;var a=n.openCanceller,u=Math.round(10*e.verno),d=!1;function p(){if(n.openCanceller!==a)throw new G.DatabaseClosed("db.open() was cancelled")}function b(){return new K(function(S,w){if(p(),!s)throw new G.MissingAPI;var _=e.name,x=n.autoSchema||!u?s.open(_):s.open(_,u);if(!x)throw new G.MissingAPI;x.onerror=pe(w),x.onblocked=wt(e._fireOnBlocked),x.onupgradeneeded=wt(function(A){var E;$=x.transaction,n.autoSchema&&!e._options.allowEmptyDB?(x.onerror=jr,$.abort(),x.result.close(),(E=s.deleteDatabase(_)).onsuccess=E.onerror=wt(function(){w(new G.NoSuchDatabase("Database ".concat(_," doesnt exist")))})):($.onerror=pe(w),A=A.oldVersion>Math.pow(2,62)?0:A.oldVersion,v=A<1,e.idbdb=x.result,d&&dl(e,$),cl(e,A/10,$,w))},w),x.onsuccess=wt(function(){$=null;var A,E,T,z,M,I=e.idbdb=x.result,q=ot(I.objectStoreNames);if(0<q.length)try{var B=I.transaction((z=q).length===1?z[0]:z,"readonly");if(n.autoSchema)E=I,T=B,(A=e).verno=E.version/10,T=A._dbSchema=Ln(0,E,T),A._storeNames=ot(E.objectStoreNames,0),Bn(A,[A._allTables],h(T),T);else if(Fn(e,e._dbSchema,B),((M=Go(Ln(0,(M=e).idbdb,B),M._dbSchema)).add.length||M.change.some(function(L){return L.add.length||L.change.length}))&&!d)return console.warn("Dexie SchemaDiff: Schema was extended without increasing the number passed to db.version(). Dexie will add missing parts and increment native version number to workaround this."),I.close(),u=I.version+1,d=!0,S(b());Rn(e,B)}catch{}fr.push(e),I.onversionchange=wt(function(L){n.vcFired=!0,e.on("versionchange").fire(L)}),I.onclose=wt(function(){e.close({disableAutoOpen:!1})}),v&&(M=e._deps,B=_,I=M.indexedDB,M=M.IDBKeyRange,Qo(I)||B===Tn||Xo(I,M).put({name:B}).catch(ft)),S()},w)}).catch(function(S){switch(S?.name){case"UnknownError":if(0<n.PR1398_maxLoop)return n.PR1398_maxLoop--,console.warn("Dexie: Workaround for Chrome UnknownError on open()"),b();break;case"VersionError":if(0<u)return u=0,b()}return K.reject(S)})}var g,y=n.dbReadyResolve,$=null,v=!1;return K.race([a,(typeof navigator>"u"?K.resolve():!navigator.userAgentData&&/Safari\//.test(navigator.userAgent)&&!/Chrom(e|ium)\//.test(navigator.userAgent)&&indexedDB.databases?new Promise(function(S){function w(){return indexedDB.databases().finally(S)}g=setInterval(w,100),w()}).finally(function(){return clearInterval(g)}):Promise.resolve()).then(b)]).then(function(){return p(),n.onReadyBeingFired=[],K.resolve(Zo(function(){return e.on.ready.fire(e.vip)})).then(function S(){if(0<n.onReadyBeingFired.length){var w=n.onReadyBeingFired.reduce(Oo,ft);return n.onReadyBeingFired=[],K.resolve(Zo(function(){return w(e.vip)})).then(S)}})}).finally(function(){n.openCanceller===a&&(n.onReadyBeingFired=null,n.isBeingOpened=!1)}).catch(function(S){n.dbOpenError=S;try{$&&$.abort()}catch{}return a===n.openCanceller&&e._close(),$t(S)}).finally(function(){n.openComplete=!0,y()}).then(function(){var S;return v&&(S={},e.tables.forEach(function(w){w.schema.indexes.forEach(function(_){_.name&&(S["idb://".concat(e.name,"/").concat(w.name,"/").concat(_.name)]=new Lt(-1/0,[[[]]]))}),S["idb://".concat(e.name,"/").concat(w.name,"/")]=S["idb://".concat(e.name,"/").concat(w.name,"/:dels")]=new Lt(-1/0,[[[]]])}),Me(Kr).fire(S),ni(S,!0)),e})}function oi(e){function n(d){return e.next(d)}var s=u(n),a=u(function(d){return e.throw(d)});function u(d){return function(g){var b=d(g),g=b.value;return b.done?g:g&&typeof g.then=="function"?g.then(s,a):m(g)?Promise.all(g).then(s,a):s(g)}}return u(n)()}function jn(e,n,s){for(var a=m(e)?e.slice():[e],u=0;u<s;++u)a.push(n);return a}var fl={stack:"dbcore",name:"VirtualIndexMiddleware",level:1,create:function(e){return i(i({},e),{table:function(n){var s=e.table(n),a=s.schema,u={},d=[];function p(v,S,w){var _=Ur(v),x=u[_]=u[_]||[],A=v==null?0:typeof v=="string"?1:v.length,E=0<S,E=i(i({},w),{name:E?"".concat(_,"(virtual-from:").concat(w.name,")"):w.name,lowLevelIndex:w,isVirtual:E,keyTail:S,keyLength:A,extractKey:Uo(v),unique:!E&&w.unique});return x.push(E),E.isPrimaryKey||d.push(E),1<A&&p(A===2?v[0]:v.slice(0,A-1),S+1,w),x.sort(function(T,z){return T.keyTail-z.keyTail}),E}n=p(a.primaryKey.keyPath,0,a.primaryKey),u[":id"]=[n];for(var b=0,g=a.indexes;b<g.length;b++){var y=g[b];p(y.keyPath,0,y)}function $(v){var S,w=v.query.index;return w.isVirtual?i(i({},v),{query:{index:w.lowLevelIndex,range:(S=v.query.range,w=w.keyTail,{type:S.type===1?2:S.type,lower:jn(S.lower,S.lowerOpen?e.MAX_KEY:e.MIN_KEY,w),lowerOpen:!0,upper:jn(S.upper,S.upperOpen?e.MIN_KEY:e.MAX_KEY,w),upperOpen:!0})}}):v}return i(i({},s),{schema:i(i({},a),{primaryKey:n,indexes:d,getIndexByKeyPath:function(v){return(v=u[Ur(v)])&&v[0]}}),count:function(v){return s.count($(v))},query:function(v){return s.query($(v))},openCursor:function(v){var S=v.query.index,w=S.keyTail,_=S.isVirtual,x=S.keyLength;return _?s.openCursor($(v)).then(function(E){return E&&A(E)}):s.openCursor(v);function A(E){return Object.create(E,{continue:{value:function(T){T!=null?E.continue(jn(T,v.reverse?e.MAX_KEY:e.MIN_KEY,w)):v.unique?E.continue(E.key.slice(0,x).concat(v.reverse?e.MIN_KEY:e.MAX_KEY,w)):E.continue()}},continuePrimaryKey:{value:function(T,z){E.continuePrimaryKey(jn(T,e.MAX_KEY,w),z)}},primaryKey:{get:function(){return E.primaryKey}},key:{get:function(){var T=E.key;return x===1?T[0]:T.slice(0,x)}},value:{get:function(){return E.value}}})}}})}})}};function ii(e,n,s,a){return s=s||{},a=a||"",h(e).forEach(function(u){var d,p,b;P(n,u)?(d=e[u],p=n[u],typeof d=="object"&&typeof p=="object"&&d&&p?(b=ie(d))!==ie(p)?s[a+u]=n[u]:b==="Object"?ii(d,p,s,a+u+"."):d!==p&&(s[a+u]=n[u]):d!==p&&(s[a+u]=n[u])):s[a+u]=void 0}),h(n).forEach(function(u){P(e,u)||(s[a+u]=n[u])}),s}function si(e,n){return n.type==="delete"?n.keys:n.keys||n.values.map(e.extractKey)}var bl={stack:"dbcore",name:"HooksMiddleware",level:2,create:function(e){return i(i({},e),{table:function(n){var s=e.table(n),a=s.schema.primaryKey;return i(i({},s),{mutate:function(u){var d=U.trans,p=d.table(n).hook,b=p.deleting,g=p.creating,y=p.updating;switch(u.type){case"add":if(g.fire===ft)break;return d._promise("readwrite",function(){return $(u)},!0);case"put":if(g.fire===ft&&y.fire===ft)break;return d._promise("readwrite",function(){return $(u)},!0);case"delete":if(b.fire===ft)break;return d._promise("readwrite",function(){return $(u)},!0);case"deleteRange":if(b.fire===ft)break;return d._promise("readwrite",function(){return(function v(S,w,_){return s.query({trans:S,values:!1,query:{index:a,range:w},limit:_}).then(function(x){var A=x.result;return $({type:"delete",keys:A,trans:S}).then(function(E){return 0<E.numFailures?Promise.reject(E.failures[0]):A.length<_?{failures:[],numFailures:0,lastResult:void 0}:v(S,i(i({},w),{lower:A[A.length-1],lowerOpen:!0}),_)})})})(u.trans,u.range,1e4)},!0)}return s.mutate(u);function $(v){var S,w,_,x=U.trans,A=v.keys||si(a,v);if(!A)throw new Error("Keys missing");return(v=v.type==="add"||v.type==="put"?i(i({},v),{keys:A}):i({},v)).type!=="delete"&&(v.values=l([],v.values)),v.keys&&(v.keys=l([],v.keys)),S=s,_=A,((w=v).type==="add"?Promise.resolve([]):S.getMany({trans:w.trans,keys:_,cache:"immutable"})).then(function(E){var T=A.map(function(z,M){var I,q,B,L=E[M],j={onerror:null,onsuccess:null};return v.type==="delete"?b.fire.call(j,z,L,x):v.type==="add"||L===void 0?(I=g.fire.call(j,z,v.values[M],x),z==null&&I!=null&&(v.keys[M]=z=I,a.outbound||ut(v.values[M],a.keyPath,z))):(I=ii(L,v.values[M]),(q=y.fire.call(j,I,z,L,x))&&(B=v.values[M],Object.keys(q).forEach(function(V){P(B,V)?B[V]=q[V]:ut(B,V,q[V])}))),j});return s.mutate(v).then(function(z){for(var M=z.failures,I=z.results,q=z.numFailures,z=z.lastResult,B=0;B<A.length;++B){var L=(I||A)[B],j=T[B];L==null?j.onerror&&j.onerror(M[B]):j.onsuccess&&j.onsuccess(v.type==="put"&&E[B]?v.values[B]:L)}return{failures:M,results:I,numFailures:q,lastResult:z}}).catch(function(z){return T.forEach(function(M){return M.onerror&&M.onerror(z)}),Promise.reject(z)})})}}})}})}};function xs(e,n,s){try{if(!n||n.keys.length<e.length)return null;for(var a=[],u=0,d=0;u<n.keys.length&&d<e.length;++u)it(n.keys[u],e[d])===0&&(a.push(s?It(n.values[u]):n.values[u]),++d);return a.length===e.length?a:null}catch{return null}}var ml={stack:"dbcore",level:-1,create:function(e){return{table:function(n){var s=e.table(n);return i(i({},s),{getMany:function(a){if(!a.cache)return s.getMany(a);var u=xs(a.keys,a.trans._cache,a.cache==="clone");return u?K.resolve(u):s.getMany(a).then(function(d){return a.trans._cache={keys:a.keys,values:a.cache==="clone"?It(d):d},d})},mutate:function(a){return a.type!=="add"&&(a.trans._cache=null),s.mutate(a)}})}}}};function ks(e,n){return e.trans.mode==="readonly"&&!!e.subscr&&!e.trans.explicit&&e.trans.db._options.cache!=="disabled"&&!n.schema.primaryKey.outbound}function Cs(e,n){switch(e){case"query":return n.values&&!n.unique;case"get":case"getMany":case"count":case"openCursor":return!1}}var vl={stack:"dbcore",level:0,name:"Observability",create:function(e){var n=e.schema.name,s=new Lt(e.MIN_KEY,e.MAX_KEY);return i(i({},e),{transaction:function(a,u,d){if(U.subscr&&u!=="readonly")throw new G.ReadOnly("Readwrite transaction in liveQuery context. Querier source: ".concat(U.querier));return e.transaction(a,u,d)},table:function(a){var u=e.table(a),d=u.schema,p=d.primaryKey,v=d.indexes,b=p.extractKey,g=p.outbound,y=p.autoIncrement&&v.filter(function(w){return w.compound&&w.keyPath.includes(p.keyPath)}),$=i(i({},u),{mutate:function(w){function _(V){return V="idb://".concat(n,"/").concat(a,"/").concat(V),z[V]||(z[V]=new Lt)}var x,A,E,T=w.trans,z=w.mutatedParts||(w.mutatedParts={}),M=_(""),I=_(":dels"),q=w.type,j=w.type==="deleteRange"?[w.range]:w.type==="delete"?[w.keys]:w.values.length<50?[si(p,w).filter(function(V){return V}),w.values]:[],B=j[0],L=j[1],j=w.trans._cache;return m(B)?(M.addKeys(B),(j=q==="delete"||B.length===L.length?xs(B,j):null)||I.addKeys(B),(j||L)&&(x=_,A=j,E=L,d.indexes.forEach(function(V){var H=x(V.name||"");function Z(nt){return nt!=null?V.extractKey(nt):null}function et(nt){return V.multiEntry&&m(nt)?nt.forEach(function(Xt){return H.addKey(Xt)}):H.addKey(nt)}(A||E).forEach(function(nt,Ft){var Q=A&&Z(A[Ft]),Ft=E&&Z(E[Ft]);it(Q,Ft)!==0&&(Q!=null&&et(Q),Ft!=null&&et(Ft))})}))):B?(L={from:(L=B.lower)!==null&&L!==void 0?L:e.MIN_KEY,to:(L=B.upper)!==null&&L!==void 0?L:e.MAX_KEY},I.add(L),M.add(L)):(M.add(s),I.add(s),d.indexes.forEach(function(V){return _(V.name).add(s)})),u.mutate(w).then(function(V){return!B||w.type!=="add"&&w.type!=="put"||(M.addKeys(V.results),y&&y.forEach(function(H){for(var Z=w.values.map(function(Q){return H.extractKey(Q)}),et=H.keyPath.findIndex(function(Q){return Q===p.keyPath}),nt=0,Xt=V.results.length;nt<Xt;++nt)Z[nt][et]=V.results[nt];_(H.name).addKeys(Z)})),T.mutatedParts=Nn(T.mutatedParts||{},z),V})}}),v=function(_){var x=_.query,_=x.index,x=x.range;return[_,new Lt((_=x.lower)!==null&&_!==void 0?_:e.MIN_KEY,(x=x.upper)!==null&&x!==void 0?x:e.MAX_KEY)]},S={get:function(w){return[p,new Lt(w.key)]},getMany:function(w){return[p,new Lt().addKeys(w.keys)]},count:v,query:v,openCursor:v};return h(S).forEach(function(w){$[w]=function(_){var x=U.subscr,A=!!x,E=ks(U,u)&&Cs(w,_)?_.obsSet={}:x;if(A){var T=function(L){return L="idb://".concat(n,"/").concat(a,"/").concat(L),E[L]||(E[L]=new Lt)},z=T(""),M=T(":dels"),x=S[w](_),A=x[0],x=x[1];if((w==="query"&&A.isPrimaryKey&&!_.values?M:T(A.name||"")).add(x),!A.isPrimaryKey){if(w!=="count"){var I=w==="query"&&g&&_.values&&u.query(i(i({},_),{values:!1}));return u[w].apply(this,arguments).then(function(L){if(w==="query"){if(g&&_.values)return I.then(function(Z){return Z=Z.result,z.addKeys(Z),L});var j=_.values?L.result.map(b):L.result;(_.values?z:M).addKeys(j)}else if(w==="openCursor"){var V=L,H=_.values;return V&&Object.create(V,{key:{get:function(){return M.addKey(V.primaryKey),V.key}},primaryKey:{get:function(){var Z=V.primaryKey;return M.addKey(Z),Z}},value:{get:function(){return H&&z.addKey(V.primaryKey),V.value}}})}return L})}M.add(s)}}return u[w].apply(this,arguments)}}),$}})}};function $s(e,n,s){if(s.numFailures===0)return n;if(n.type==="deleteRange")return null;var a=n.keys?n.keys.length:"values"in n&&n.values?n.values.length:1;return s.numFailures===a?null:(n=i({},n),m(n.keys)&&(n.keys=n.keys.filter(function(u,d){return!(d in s.failures)})),"values"in n&&m(n.values)&&(n.values=n.values.filter(function(u,d){return!(d in s.failures)})),n)}function ai(e,n){return s=e,((a=n).lower===void 0||(a.lowerOpen?0<it(s,a.lower):0<=it(s,a.lower)))&&(e=e,(n=n).upper===void 0||(n.upperOpen?it(e,n.upper)<0:it(e,n.upper)<=0));var s,a}function As(e,n,S,a,u,d){if(!S||S.length===0)return e;var p=n.query.index,b=p.multiEntry,g=n.query.range,y=a.schema.primaryKey.extractKey,$=p.extractKey,v=(p.lowLevelIndex||p).extractKey,S=S.reduce(function(w,_){var x=w,A=[];if(_.type==="add"||_.type==="put")for(var E=new Lt,T=_.values.length-1;0<=T;--T){var z,M=_.values[T],I=y(M);E.hasKey(I)||(z=$(M),(b&&m(z)?z.some(function(V){return ai(V,g)}):ai(z,g))&&(E.addKey(I),A.push(M)))}switch(_.type){case"add":var q=new Lt().addKeys(n.values?w.map(function(H){return y(H)}):w),x=w.concat(n.values?A.filter(function(H){return H=y(H),!q.hasKey(H)&&(q.addKey(H),!0)}):A.map(function(H){return y(H)}).filter(function(H){return!q.hasKey(H)&&(q.addKey(H),!0)}));break;case"put":var B=new Lt().addKeys(_.values.map(function(H){return y(H)}));x=w.filter(function(H){return!B.hasKey(n.values?y(H):H)}).concat(n.values?A:A.map(function(H){return y(H)}));break;case"delete":var L=new Lt().addKeys(_.keys);x=w.filter(function(H){return!L.hasKey(n.values?y(H):H)});break;case"deleteRange":var j=_.range;x=w.filter(function(H){return!ai(y(H),j)})}return x},e);return S===e?e:(S.sort(function(w,_){return it(v(w),v(_))||it(y(w),y(_))}),n.limit&&n.limit<1/0&&(S.length>n.limit?S.length=n.limit:e.length===n.limit&&S.length<n.limit&&(u.dirty=!0)),d?Object.freeze(S):S)}function Ss(e,n){return it(e.lower,n.lower)===0&&it(e.upper,n.upper)===0&&!!e.lowerOpen==!!n.lowerOpen&&!!e.upperOpen==!!n.upperOpen}function gl(e,n){return(function(s,a,u,d){if(s===void 0)return a!==void 0?-1:0;if(a===void 0)return 1;if((a=it(s,a))===0){if(u&&d)return 0;if(u)return 1;if(d)return-1}return a})(e.lower,n.lower,e.lowerOpen,n.lowerOpen)<=0&&0<=(function(s,a,u,d){if(s===void 0)return a!==void 0?1:0;if(a===void 0)return-1;if((a=it(s,a))===0){if(u&&d)return 0;if(u)return-1;if(d)return 1}return a})(e.upper,n.upper,e.upperOpen,n.upperOpen)}function yl(e,n,s,a){e.subscribers.add(s),a.addEventListener("abort",function(){var u,d;e.subscribers.delete(s),e.subscribers.size===0&&(u=e,d=n,setTimeout(function(){u.subscribers.size===0&&Et(d,u)},3e3))})}var wl={stack:"dbcore",level:0,name:"Cache",create:function(e){var n=e.schema.name;return i(i({},e),{transaction:function(s,a,u){var d,p,b=e.transaction(s,a,u);return a==="readwrite"&&(p=(d=new AbortController).signal,u=function(g){return function(){if(d.abort(),a==="readwrite"){for(var y=new Set,$=0,v=s;$<v.length;$++){var S=v[$],w=Je["idb://".concat(n,"/").concat(S)];if(w){var _=e.table(S),x=w.optimisticOps.filter(function(H){return H.trans===b});if(b._explicit&&g&&b.mutatedParts)for(var A=0,E=Object.values(w.queries.query);A<E.length;A++)for(var T=0,z=(q=E[A]).slice();T<z.length;T++)ti((B=z[T]).obsSet,b.mutatedParts)&&(Et(q,B),B.subscribers.forEach(function(H){return y.add(H)}));else if(0<x.length){w.optimisticOps=w.optimisticOps.filter(function(H){return H.trans!==b});for(var M=0,I=Object.values(w.queries.query);M<I.length;M++)for(var q,B,L,j=0,V=(q=I[M]).slice();j<V.length;j++)(B=V[j]).res!=null&&b.mutatedParts&&(g&&!B.dirty?(L=Object.isFrozen(B.res),L=As(B.res,B.req,x,_,B,L),B.dirty?(Et(q,B),B.subscribers.forEach(function(H){return y.add(H)})):L!==B.res&&(B.res=L,B.promise=K.resolve({result:L}))):(B.dirty&&Et(q,B),B.subscribers.forEach(function(H){return y.add(H)})))}}}y.forEach(function(H){return H()})}}},b.addEventListener("abort",u(!1),{signal:p}),b.addEventListener("error",u(!1),{signal:p}),b.addEventListener("complete",u(!0),{signal:p})),b},table:function(s){var a=e.table(s),u=a.schema.primaryKey;return i(i({},a),{mutate:function(d){var p=U.trans;if(u.outbound||p.db._options.cache==="disabled"||p.explicit||p.idbtrans.mode!=="readwrite")return a.mutate(d);var b=Je["idb://".concat(n,"/").concat(s)];return b?(p=a.mutate(d),d.type!=="add"&&d.type!=="put"||!(50<=d.values.length||si(u,d).some(function(g){return g==null}))?(b.optimisticOps.push(d),d.mutatedParts&&qn(d.mutatedParts),p.then(function(g){0<g.numFailures&&(Et(b.optimisticOps,d),(g=$s(0,d,g))&&b.optimisticOps.push(g),d.mutatedParts&&qn(d.mutatedParts))}),p.catch(function(){Et(b.optimisticOps,d),d.mutatedParts&&qn(d.mutatedParts)})):p.then(function(g){var y=$s(0,i(i({},d),{values:d.values.map(function($,v){var S;return g.failures[v]?$:($=(S=u.keyPath)!==null&&S!==void 0&&S.includes(".")?It($):i({},$),ut($,u.keyPath,g.results[v]),$)})}),g);b.optimisticOps.push(y),queueMicrotask(function(){return d.mutatedParts&&qn(d.mutatedParts)})}),p):a.mutate(d)},query:function(d){if(!ks(U,a)||!Cs("query",d))return a.query(d);var p=((y=U.trans)===null||y===void 0?void 0:y.db._options.cache)==="immutable",v=U,b=v.requery,g=v.signal,y=(function(_,x,A,E){var T=Je["idb://".concat(_,"/").concat(x)];if(!T)return[];if(!(x=T.queries[A]))return[null,!1,T,null];var z=x[(E.query?E.query.index.name:null)||""];if(!z)return[null,!1,T,null];switch(A){case"query":var M=z.find(function(I){return I.req.limit===E.limit&&I.req.values===E.values&&Ss(I.req.query.range,E.query.range)});return M?[M,!0,T,z]:[z.find(function(I){return("limit"in I.req?I.req.limit:1/0)>=E.limit&&(!E.values||I.req.values)&&gl(I.req.query.range,E.query.range)}),!1,T,z];case"count":return M=z.find(function(I){return Ss(I.req.query.range,E.query.range)}),[M,!!M,T,z]}})(n,s,"query",d),$=y[0],v=y[1],S=y[2],w=y[3];return $&&v?$.obsSet=d.obsSet:(v=a.query(d).then(function(_){var x=_.result;if($&&($.res=x),p){for(var A=0,E=x.length;A<E;++A)Object.freeze(x[A]);Object.freeze(x)}else _.result=It(x);return _}).catch(function(_){return w&&$&&Et(w,$),Promise.reject(_)}),$={obsSet:d.obsSet,promise:v,subscribers:new Set,type:"query",req:d,dirty:!1},w?w.push($):(w=[$],(S=S||(Je["idb://".concat(n,"/").concat(s)]={queries:{query:{},count:{}},objs:new Map,optimisticOps:[],unsignaledParts:{}})).queries.query[d.query.index.name||""]=w)),yl($,w,b,g),$.promise.then(function(_){return{result:As(_.result,d,S?.optimisticOps,a,$,p)}})}})}})}};function Kn(e,n){return new Proxy(e,{get:function(s,a,u){return a==="db"?n:Reflect.get(s,a,u)}})}var _e=(At.prototype.version=function(e){if(isNaN(e)||e<.1)throw new G.Type("Given version is not a positive number");if(e=Math.round(10*e)/10,this.idbdb||this._state.isBeingOpened)throw new G.Schema("Cannot add version when database is open");this.verno=Math.max(this.verno,e);var n=this._versions,s=n.filter(function(a){return a._cfg.version===e})[0];return s||(s=new this.Version(e),n.push(s),n.sort(ul),s.stores({}),this._state.autoSchema=!1,s)},At.prototype._whenReady=function(e){var n=this;return this.idbdb&&(this._state.openComplete||U.letThrough||this._vip)?e():new K(function(s,a){if(n._state.openComplete)return a(new G.DatabaseClosed(n._state.dbOpenError));if(!n._state.isBeingOpened){if(!n._state.autoOpen)return void a(new G.DatabaseClosed);n.open().catch(ft)}n._state.dbReadyPromise.then(s,a)}).then(e)},At.prototype.use=function(e){var n=e.stack,s=e.create,a=e.level,u=e.name;return u&&this.unuse({stack:n,name:u}),e=this._middlewares[n]||(this._middlewares[n]=[]),e.push({stack:n,create:s,level:a??10,name:u}),e.sort(function(d,p){return d.level-p.level}),this},At.prototype.unuse=function(e){var n=e.stack,s=e.name,a=e.create;return n&&this._middlewares[n]&&(this._middlewares[n]=this._middlewares[n].filter(function(u){return a?u.create!==a:!!s&&u.name!==s})),this},At.prototype.open=function(){var e=this;return Xe(Ee,function(){return pl(e)})},At.prototype._close=function(){this.on.close.fire(new CustomEvent("close"));var e=this._state,n=fr.indexOf(this);if(0<=n&&fr.splice(n,1),this.idbdb){try{this.idbdb.close()}catch{}this.idbdb=null}e.isBeingOpened||(e.dbReadyPromise=new K(function(s){e.dbReadyResolve=s}),e.openCanceller=new K(function(s,a){e.cancelOpen=a}))},At.prototype.close=function(s){var n=(s===void 0?{disableAutoOpen:!0}:s).disableAutoOpen,s=this._state;n?(s.isBeingOpened&&s.cancelOpen(new G.DatabaseClosed),this._close(),s.autoOpen=!1,s.dbOpenError=new G.DatabaseClosed):(this._close(),s.autoOpen=this._options.autoOpen||s.isBeingOpened,s.openComplete=!1,s.dbOpenError=null)},At.prototype.delete=function(e){var n=this;e===void 0&&(e={disableAutoOpen:!0});var s=0<arguments.length&&typeof arguments[0]!="object",a=this._state;return new K(function(u,d){function p(){n.close(e);var b=n._deps.indexedDB.deleteDatabase(n.name);b.onsuccess=wt(function(){var g,y,$;g=n._deps,y=n.name,$=g.indexedDB,g=g.IDBKeyRange,Qo($)||y===Tn||Xo($,g).delete(y).catch(ft),u()}),b.onerror=pe(d),b.onblocked=n._fireOnBlocked}if(s)throw new G.InvalidArgument("Invalid closeOptions argument to db.delete()");a.isBeingOpened?a.dbReadyPromise.then(p):p()})},At.prototype.backendDB=function(){return this.idbdb},At.prototype.isOpen=function(){return this.idbdb!==null},At.prototype.hasBeenClosed=function(){var e=this._state.dbOpenError;return e&&e.name==="DatabaseClosed"},At.prototype.hasFailed=function(){return this._state.dbOpenError!==null},At.prototype.dynamicallyOpened=function(){return this._state.autoSchema},Object.defineProperty(At.prototype,"tables",{get:function(){var e=this;return h(this._allTables).map(function(n){return e._allTables[n]})},enumerable:!1,configurable:!0}),At.prototype.transaction=function(){var e=function(n,s,a){var u=arguments.length;if(u<2)throw new G.InvalidArgument("Too few arguments");for(var d=new Array(u-1);--u;)d[u-1]=arguments[u];return a=d.pop(),[n,jt(d),a]}.apply(this,arguments);return this._transaction.apply(this,e)},At.prototype._transaction=function(e,n,s){var a=this,u=U.trans;u&&u.db===this&&e.indexOf("!")===-1||(u=null);var d,p,b=e.indexOf("?")!==-1;e=e.replace("!","").replace("?","");try{if(p=n.map(function(y){if(y=y instanceof a.Table?y.name:y,typeof y!="string")throw new TypeError("Invalid table argument to Dexie.transaction(). Only Table or String are allowed");return y}),e=="r"||e===Fo)d=Fo;else{if(e!="rw"&&e!=Vo)throw new G.InvalidArgument("Invalid transaction mode: "+e);d=Vo}if(u){if(u.mode===Fo&&d===Vo){if(!b)throw new G.SubTransaction("Cannot enter a sub-transaction with READWRITE mode when parent transaction is READONLY");u=null}u&&p.forEach(function(y){if(u&&u.storeNames.indexOf(y)===-1){if(!b)throw new G.SubTransaction("Table "+y+" not included in parent transaction.");u=null}}),b&&u&&!u.active&&(u=null)}}catch(y){return u?u._promise(null,function($,v){v(y)}):$t(y)}var g=function y($,v,S,w,_){return K.resolve().then(function(){var x=U.transless||U,A=$._createTransaction(v,S,$._dbSchema,w);if(A.explicit=!0,x={trans:A,transless:x},w)A.idbtrans=w.idbtrans;else try{A.create(),A.idbtrans._explicit=!0,$._state.PR1398_maxLoop=3}catch(z){return z.name===To.InvalidState&&$.isOpen()&&0<--$._state.PR1398_maxLoop?(console.warn("Dexie: Need to reopen db"),$.close({disableAutoOpen:!1}),$.open().then(function(){return y($,v,S,null,_)})):$t(z)}var E,T=Eo(_);return T&&pr(),x=K.follow(function(){var z;(E=_.call(A,A))&&(T?(z=Oe.bind(null,null),E.then(z,z)):typeof E.next=="function"&&typeof E.throw=="function"&&(E=oi(E)))},x),(E&&typeof E.then=="function"?K.resolve(E).then(function(z){return A.active?z:$t(new G.PrematureCommit("Transaction committed too early. See http://bit.ly/2kdckMn"))}):x.then(function(){return E})).then(function(z){return w&&A._resolve(),A._completion.then(function(){return z})}).catch(function(z){return A._reject(z),$t(z)})})}.bind(null,this,d,p,u,s);return u?u._promise(d,g,"lock"):U.trans?Xe(U.transless,function(){return a._whenReady(g)}):this._whenReady(g)},At.prototype.table=function(e){if(!P(this._allTables,e))throw new G.InvalidTable("Table ".concat(e," does not exist"));return this._allTables[e]},At);function At(e,n){var s=this;this._middlewares={},this.verno=0;var a=At.dependencies;this._options=n=i({addons:At.addons,autoOpen:!0,indexedDB:a.indexedDB,IDBKeyRange:a.IDBKeyRange,cache:"cloned"},n),this._deps={indexedDB:n.indexedDB,IDBKeyRange:n.IDBKeyRange},a=n.addons,this._dbSchema={},this._versions=[],this._storeNames=[],this._allTables={},this.idbdb=null,this._novip=this;var u,d,p,b,g,y={dbOpenError:null,isBeingOpened:!1,onReadyBeingFired:null,openComplete:!1,dbReadyResolve:ft,dbReadyPromise:null,cancelOpen:ft,openCanceller:null,autoSchema:!0,PR1398_maxLoop:3,autoOpen:n.autoOpen};y.dbReadyPromise=new K(function(v){y.dbReadyResolve=v}),y.openCanceller=new K(function(v,S){y.cancelOpen=S}),this._state=y,this.name=e,this.on=Nr(this,"populate","blocked","versionchange","close",{ready:[Oo,ft]}),this.once=function(v,S){var w=function(){for(var _=[],x=0;x<arguments.length;x++)_[x]=arguments[x];s.on(v).unsubscribe(w),S.apply(s,_)};return s.on(v,w)},this.on.ready.subscribe=dt(this.on.ready.subscribe,function(v){return function(S,w){At.vip(function(){var _,x=s._state;x.openComplete?(x.dbOpenError||K.resolve().then(S),w&&v(S)):x.onReadyBeingFired?(x.onReadyBeingFired.push(S),w&&v(S)):(v(S),_=s,w||v(function A(){_.on.ready.unsubscribe(S),_.on.ready.unsubscribe(A)}))})}}),this.Collection=(u=this,qr(rl.prototype,function(E,A){this.db=u;var w=rs,_=null;if(A)try{w=A()}catch(T){_=T}var x=E._ctx,A=x.table,E=A.hook.reading.fire;this._ctx={table:A,index:x.index,isPrimKey:!x.index||A.schema.primKey.keyPath&&x.index===A.schema.primKey.name,range:w,keysOnly:!1,dir:"next",unique:"",algorithm:null,filter:null,replayFilter:null,justLimit:!0,isMatch:null,offset:0,limit:1/0,error:_,or:x.or,valueMapper:E!==Rr?E:null}})),this.Table=(d=this,qr(ls.prototype,function(v,S,w){this.db=d,this._tx=w,this.name=v,this.schema=S,this.hook=d._allTables[v]?d._allTables[v].hook:Nr(null,{creating:[Wa,ft],reading:[Ua,Rr],updating:[Ya,ft],deleting:[Ga,ft]})})),this.Transaction=(p=this,qr(il.prototype,function(v,S,w,_,x){var A=this;v!=="readonly"&&S.forEach(function(E){E=(E=w[E])===null||E===void 0?void 0:E.yProps,E&&(S=S.concat(E.map(function(T){return T.updatesTable})))}),this.db=p,this.mode=v,this.storeNames=S,this.schema=w,this.chromeTransactionDurability=_,this.idbtrans=null,this.on=Nr(this,"complete","error","abort"),this.parent=x||null,this.active=!0,this._reculock=0,this._blockedFuncs=[],this._resolve=null,this._reject=null,this._waitingFor=null,this._waitingQueue=null,this._spinCount=0,this._completion=new K(function(E,T){A._resolve=E,A._reject=T}),this._completion.then(function(){A.active=!1,A.on.complete.fire()},function(E){var T=A.active;return A.active=!1,A.on.error.fire(E),A.parent?A.parent._reject(E):T&&A.idbtrans&&A.idbtrans.abort(),$t(E)})})),this.Version=(b=this,qr(hl.prototype,function(v){this.db=b,this._cfg={version:v,storesSource:null,dbschema:{},tables:{},contentUpgrade:null}})),this.WhereClause=(g=this,qr(ps.prototype,function(v,S,w){if(this.db=g,this._ctx={table:v,index:S===":id"?null:S,or:w},this._cmp=this._ascending=it,this._descending=function(_,x){return it(x,_)},this._max=function(_,x){return 0<it(_,x)?_:x},this._min=function(_,x){return it(_,x)<0?_:x},this._IDBKeyRange=g._deps.IDBKeyRange,!this._IDBKeyRange)throw new G.MissingAPI})),this.on("versionchange",function(v){0<v.newVersion?console.warn("Another connection wants to upgrade database '".concat(s.name,"'. Closing db now to resume the upgrade.")):console.warn("Another connection wants to delete database '".concat(s.name,"'. Closing db now to resume the delete request.")),s.close({disableAutoOpen:!1})}),this.on("blocked",function(v){!v.newVersion||v.newVersion<v.oldVersion?console.warn("Dexie.delete('".concat(s.name,"') was blocked")):console.warn("Upgrade '".concat(s.name,"' blocked by other connection holding version ").concat(v.oldVersion/10))}),this._maxKey=Hr(n.IDBKeyRange),this._createTransaction=function(v,S,w,_){return new s.Transaction(v,S,w,s._options.chromeTransactionDurability,_)},this._fireOnBlocked=function(v){s.on("blocked").fire(v),fr.filter(function(S){return S.name===s.name&&S!==s&&!S._state.vcFired}).map(function(S){return S.on("versionchange").fire(v)})},this.use(ml),this.use(wl),this.use(vl),this.use(fl),this.use(bl);var $=new Proxy(this,{get:function(v,S,w){if(S==="_vip")return!0;if(S==="table")return function(x){return Kn(s.table(x),$)};var _=Reflect.get(v,S,w);return _ instanceof ls?Kn(_,$):S==="tables"?_.map(function(x){return Kn(x,$)}):S==="_createTransaction"?function(){return Kn(_.apply(this,arguments),$)}:_}});this.vip=$,a.forEach(function(v){return v(s)})}var Hn,re=typeof Symbol<"u"&&"observable"in Symbol?Symbol.observable:"@@observable",_l=(li.prototype.subscribe=function(e,n,s){return this._subscribe(e&&typeof e!="function"?e:{next:e,error:n,complete:s})},li.prototype[re]=function(){return this},li);function li(e){this._subscribe=e}try{Hn={indexedDB:c.indexedDB||c.mozIndexedDB||c.webkitIndexedDB||c.msIndexedDB,IDBKeyRange:c.IDBKeyRange||c.webkitIDBKeyRange}}catch{Hn={indexedDB:null,IDBKeyRange:null}}function Es(e){var n,s=!1,a=new _l(function(u){var d=Eo(e),p,b=!1,g={},y={},$={get closed(){return b},unsubscribe:function(){b||(b=!0,p&&p.abort(),v&&Me.storagemutated.unsubscribe(w))}};u.start&&u.start($);var v=!1,S=function(){return Lo(_)},w=function(x){Nn(g,x),ti(y,g)&&S()},_=function(){var x,A,E;!b&&Hn.indexedDB&&(g={},x={},p&&p.abort(),p=new AbortController,E=(function(T){var z=dr();try{d&&pr();var M=Te(e,T);return M=d?M.finally(Oe):M}finally{z&&hr()}})(A={subscr:x,signal:p.signal,requery:S,querier:e,trans:null}),Promise.resolve(E).then(function(T){s=!0,n=T,b||A.signal.aborted||(g={},(function(z){for(var M in z)if(P(z,M))return;return 1})(y=x)||v||(Me(Kr,w),v=!0),Lo(function(){return!b&&u.next&&u.next(T)}))},function(T){s=!1,["DatabaseClosedError","AbortError"].includes(T?.name)||b||Lo(function(){b||u.error&&u.error(T)})}))};return setTimeout(S,0),$});return a.hasValue=function(){return s},a.getValue=function(){return n},a}var tr=_e;function ui(e){var n=De;try{De=!0,Me.storagemutated.fire(e),ni(e,!0)}finally{De=n}}F(tr,i(i({},wn),{delete:function(e){return new tr(e,{addons:[]}).delete()},exists:function(e){return new tr(e,{addons:[]}).open().then(function(n){return n.close(),!0}).catch("NoSuchDatabaseError",function(){return!1})},getDatabaseNames:function(e){try{return n=tr.dependencies,s=n.indexedDB,n=n.IDBKeyRange,(Qo(s)?Promise.resolve(s.databases()).then(function(a){return a.map(function(u){return u.name}).filter(function(u){return u!==Tn})}):Xo(s,n).toCollection().primaryKeys()).then(e)}catch{return $t(new G.MissingAPI)}var n,s},defineClass:function(){return function(e){k(this,e)}},ignoreTransaction:function(e){return U.trans?Xe(U.transless,e):e()},vip:Zo,async:function(e){return function(){try{var n=oi(e.apply(this,arguments));return n&&typeof n.then=="function"?n:K.resolve(n)}catch(s){return $t(s)}}},spawn:function(e,n,s){try{var a=oi(e.apply(s,n||[]));return a&&typeof a.then=="function"?a:K.resolve(a)}catch(u){return $t(u)}},currentTransaction:{get:function(){return U.trans||null}},waitFor:function(e,n){return n=K.resolve(typeof e=="function"?tr.ignoreTransaction(e):e).timeout(n||6e4),U.trans?U.trans.waitFor(n):n},Promise:K,debug:{get:function(){return he},set:function(e){Yi(e)}},derive:W,extend:k,props:F,override:dt,Events:Nr,on:Me,liveQuery:Es,extendObservabilitySet:Nn,getByKeyPath:Ct,setByKeyPath:ut,delByKeyPath:function(e,n){typeof n=="string"?ut(e,n,void 0):"length"in n&&[].map.call(n,function(s){ut(e,s,void 0)})},shallowClone:te,deepClone:It,getObjectDiff:ii,cmp:it,asap:vt,minKey:-1/0,addons:[],connections:fr,errnames:To,dependencies:Hn,cache:Je,semVer:"4.2.1",version:"4.2.1".split(".").map(function(e){return parseInt(e)}).reduce(function(e,n,s){return e+n/Math.pow(10,2*s)})})),tr.maxKey=Hr(tr.dependencies.IDBKeyRange),typeof dispatchEvent<"u"&&typeof addEventListener<"u"&&(Me(Kr,function(e){De||(e=new CustomEvent(jo,{detail:e}),De=!0,dispatchEvent(e),De=!1)}),addEventListener(jo,function(e){e=e.detail,De||ui(e)}));var gr,De=!1,Ts=function(){};return typeof BroadcastChannel<"u"&&((Ts=function(){(gr=new BroadcastChannel(jo)).onmessage=function(e){return e.data&&ui(e.data)}})(),typeof gr.unref=="function"&&gr.unref(),Me(Kr,function(e){De||gr.postMessage(e)})),typeof addEventListener<"u"&&(addEventListener("pagehide",function(e){if(!_e.disableBfCache&&e.persisted){he&&console.debug("Dexie: handling persisted pagehide"),gr?.close();for(var n=0,s=fr;n<s.length;n++)s[n].close({disableAutoOpen:!1})}}),addEventListener("pageshow",function(e){!_e.disableBfCache&&e.persisted&&(he&&console.debug("Dexie: handling persisted pageshow"),Ts(),ui({all:new Lt(-1/0,[[]])}))})),K.rejectionMapper=function(e,n){return!e||e instanceof ur||e instanceof TypeError||e instanceof SyntaxError||!e.name||!Gi[e.name]?e:(n=new Gi[e.name](n||e.message,e),"stack"in e&&N(n,"stack",{get:function(){return this.inner.stack}}),n)},Yi(he),i(_e,Object.freeze({__proto__:null,Dexie:_e,liveQuery:Es,Entity:ns,cmp:it,PropModification:Vr,replacePrefix:function(e,n){return new Vr({replacePrefix:[e,n]})},add:function(e){return new Vr({add:e})},remove:function(e){return new Vr({remove:e})},default:_e,RangeSet:Lt,mergeRanges:Gr,rangesOverlap:gs}),{default:_e}),_e})})(Jn)),Jn.exports}var Vd=Fd();const Ei=Id(Vd),ha=Symbol.for("Dexie"),co=globalThis[ha]||(globalThis[ha]=Ei);if(Ei.semVer!==co.semVer)throw new Error(`Two different versions of Dexie loaded in the same app: ${Ei.semVer} and ${co.semVer}`);const{liveQuery:Nd,mergeRanges:ph,rangesOverlap:fh,RangeSet:bh,cmp:mh,Entity:vh,PropModification:gh,replacePrefix:yh,add:wh,remove:_h,DexieYProvider:xh}=co,to={PENDING:{code:"0"},PROGRESS:{code:"5"},DONE:{code:"9"}};class qd extends co{constructor(){super("TaskItDB"),this.version(1).stores({task:"++id, title, status, createdAt"})}async addTask(r){const o=new Date,i={title:r,status:to.PENDING.code,members:[],checkboxes:[],dueDate:void 0,createdAt:o,updatedAt:o};return await this.task.add(i)}async getTaskById(r){return await this.task.get(r)}async updateTask(r){r.updatedAt=new Date,await this.task.put(r)}}const pn=new qd,qa=".scrollable{overflow-y:scroll;scroll-behavior:smooth}.scrollable::-webkit-scrollbar{width:12px}.scrollable::-webkit-scrollbar-thumb{background-color:var(--sl-color-neutral-400);border-radius:var(--sl-border-radius-medium);border-right:4px solid transparent;border-left:4px solid transparent;background-clip:padding-box}.scrollable::-webkit-scrollbar-thumb:hover{background-color:var(--sl-color-neutral-500)}.scrollable::-webkit-scrollbar-thumb:active{background-color:var(--sl-color-neutral-600)}.scrollable::-webkit-scrollbar-track{background:transparent;border-radius:var(--sl-border-radius-medium)}",jd=":host{display:block;height:100%}#root{height:100%;margin-left:var(--sl-spacing-2x-small);display:flex;flex-direction:column}#root sl-tab-group{flex:1 1 auto;overflow:hidden}#root sl-tab-group::part(base){height:100%;display:flex;flex-direction:column}#root sl-tab-group::part(body){flex:1 1 auto}#root sl-tab-group sl-tab sl-icon{margin-right:var(--sl-spacing-2x-small)}#root sl-tab-group sl-tab span{margin-top:-2px}#root sl-tab-group sl-tab-panel{height:100%}#root sl-tab-group sl-tab-panel::part(base){height:100%;padding:var(--sl-spacing-x-small) 0;padding-right:0}#root sl-tab-group sl-tab-panel .task-list{height:100%}#root .button-area{flex:0 0 auto}#root .button-area sl-button{width:100%}#root .button-area sl-button::part(label){display:flex;align-items:center}#root .button-area sl-button sl-icon{font-size:var(--sl-font-size-large)}";var Kd=Object.defineProperty,Hd=Object.getOwnPropertyDescriptor,Dr=(t,r,o,i)=>{for(var l=i>1?void 0:i?Hd(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&Kd(r,o,l),l};Le("/");let qe=class extends ae{constructor(){super(),this._pendingTasks=[],this._progressTasks=[],this._doneTasks=[]}connectedCallback(){super.connectedCallback(),this._subscribeToTasks()}disconnectedCallback(){super.disconnectedCallback(),this._dbSubscription?.unsubscribe()}willUpdate(t){super.willUpdate(t)}render(){return X` <div id="root">
+      <sl-tab-group>
+        <sl-tab slot="nav" panel="pending">
+          <sl-icon library="taskit" name="square"></sl-icon>
+          <span>未対応</span>
+        </sl-tab>
+        <sl-tab slot="nav" panel="progress">
+          <sl-icon library="taskit" name="square-half"></sl-icon>
+          <span>対応中</span>
+        </sl-tab>
+        <sl-tab slot="nav" panel="done">
+          <sl-icon library="taskit" name="check-square"></sl-icon>
+          <span>対応済</span>
+        </sl-tab>
+
+        <sl-tab-panel name="pending">
+          <div class="task-list scrollable">
+            ${wi(this._pendingTasks,t=>t.id,t=>X`
+                <ti-taskitem .taskId=${t.id} .dueDate=${t.dueDate}>
+                  ${t.title}
+                </ti-taskitem>
+              `)}
+          </div>
+        </sl-tab-panel>
+        <sl-tab-panel name="progress">
+          <div class="task-list scrollable">
+            ${wi(this._progressTasks,t=>t.id,t=>X`
+                <ti-taskitem .task=${t}>${t.title}</ti-taskitem>
+              `)}
+          </div>
+        </sl-tab-panel>
+        <sl-tab-panel name="done">
+          <div class="task-list scrollable">
+            ${wi(this._doneTasks,t=>t.id,t=>X`
+                <ti-taskitem .task=${t}>${t.title}</ti-taskitem>
+              `)}
+          </div>
+        </sl-tab-panel>
+      </sl-tab-group>
+      <div class="button-area">
+        <sl-tooltip content="Add Task" placement="top">
+          <sl-button
+            variant="primary"
+            id="add-task-button"
+            @click=${()=>this.addTaskDialog.show()}
+          >
+            <sl-icon library="taskit" name="journal-plus"></sl-icon>
+          </sl-button>
+        </sl-tooltip>
+        <sl-dialog
+          id="add-task-dialog"
+          label="新規タスクを追加"
+          @sl-request-close=${this._handleRequestClose}
+        >
+          <div class="dialog-content">
+            <sl-input placeholder="タスク名" id="new-task-title">
+              <sl-icon
+                library="taskit"
+                name="card-text"
+                slot="prefix"
+              >
+            </sl-input>
+          </div>
+          <sl-button slot="footer" variant="primary" id="save-task-button" @click=${this._addTask}>
+            <sl-icon library="taskit" name="floppy"></sl-icon>
+          </sl-button>
+        </sl-dialog>
+      </div>
+    </div>`}_handleRequestClose(){this.newTaskTitleInput.value="",document.activeElement?.blur()}async _addTask(){const t=this.newTaskTitleInput.value?.trim();if(t)try{await pn.addTask(t),this._handleRequestClose(),this.addTaskDialog.hide()}catch(r){console.error("Failed Add Task:",r)}}_subscribeToTasks(){const t=Nd(()=>pn.task.toArray());this._dbSubscription=t.subscribe({next:r=>{this._pendingTasks=r.filter(o=>o.status===to.PENDING.code),this._progressTasks=r.filter(o=>o.status===to.PROGRESS.code),this._doneTasks=r.filter(o=>o.status===to.DONE.code)},error:r=>console.error("LiveQuery Error:",r)})}};qe.styles=[ct`
+      ${Ae(qa)}
+    `,ct`
+      ${Ae(jd)}
+    `];Dr([st("#add-task-dialog")],qe.prototype,"addTaskDialog",2);Dr([st("#new-task-title")],qe.prototype,"newTaskTitleInput",2);Dr([_t()],qe.prototype,"_pendingTasks",2);Dr([_t()],qe.prototype,"_progressTasks",2);Dr([_t()],qe.prototype,"_doneTasks",2);qe=Dr([Tr("ti-tasklist")],qe);function Ud(t,r="yyyy/MM/dd HH:mm:ss"){if(!t)return"";const o=l=>String(l).padStart(2,"0"),i={yyyy:t.getFullYear(),MM:o(t.getMonth()+1),dd:o(t.getDate()),HH:o(t.getHours()),mm:o(t.getMinutes()),ss:o(t.getSeconds())};return r.replace(/yyyy|MM|dd|HH|mm|ss/g,l=>i[l].toString())}function Wd(t){const r=new Date;return r.setHours(0,0,0,0),r.setDate(r.getDate()+t),r}function Ti(t,r,o){const i=new CustomEvent(r,{bubbles:!0,composed:!0,cancelable:!0,detail:{},...o});return t.dispatchEvent(i),i}const Gd="#root{cursor:pointer;width:100%;font-size:var(--sl-font-size-small);display:flex;flex-direction:row}#root:hover{background-color:var(--sl-color-neutral-200)}#root .label{flex:1 1 auto;display:flex;align-items:center;overflow:hidden;padding:1px var(--sl-spacing-2x-small);padding-right:0}#root .label:hover{color:var(--sl-color-primary-800);text-decoration:underline;font-weight:700}#root .label .task-title{margin-top:-1px;margin-left:2px;width:100%;text-overflow:ellipsis;overflow:hidden;white-space:nowrap}#root .overdue{color:var(--sl-color-danger-600)}#root .icon{flex:0 0 auto}";var Yd=Object.defineProperty,Xd=Object.getOwnPropertyDescriptor,Ao=(t,r,o,i)=>{for(var l=i>1?void 0:i?Xd(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&Yd(r,o,l),l};Le("/");let Ar=class extends ae{constructor(){super(),this.title=""}connectedCallback(){super.connectedCallback()}disconnectedCallback(){super.disconnectedCallback()}willUpdate(t){super.willUpdate(t)}handleSlotChange(t){const r=t.target;this.title=r.assignedNodes({flatten:!0}).map(o=>o.textContent??"").join("").trim()}render(){const t=!this.dueDate||new Date(this.dueDate)<Wd(3);return X`<div id="root">
+      <sl-tooltip placement="right">
+        <div class="${kt({label:!0,overdue:t})}">
+          <sl-icon
+            library="taskit"
+            name="${t?"exclamation-square-fill":"card-text"}"
+            class="icon"
+          ></sl-icon>
+          <div class="task-title" @click=${this._handleClickTaskItem}>
+            <slot @slotchange=${this.handleSlotChange}></slot>
+          </div>
+        </div>
+        <div slot="content">
+          ${this.title}<br />
+          期限日:${Ud(this.dueDate)}
+        </div>
+      </sl-tooltip>
+      <sl-dropdown>
+        <sl-icon-button
+          library="taskit"
+          name="chevron-right"
+          class="icon"
+          slot="trigger"
+        ></sl-icon-button>
+        <sl-menu>
+          <sl-menu-item @click=${this._deleteTask}>削除</sl-menu-item>
+        </sl-menu>
+      </sl-dropdown>
+    </div>`}_handleClickTaskItem(){Ti(this,"ti-taskitem-click",{detail:{taskId:this.taskId}})}async _deleteTask(){if(this.taskId&&confirm(`タスク「${this.title}」を削除しますか？`))try{await pn.task.delete(this.taskId)}catch(t){console.error("Failed to delete task:",t)}}};Ar.styles=ct`
+    ${Ae(Gd)}
+  `;Ao([C({type:Number})],Ar.prototype,"taskId",2);Ao([C({type:Date})],Ar.prototype,"dueDate",2);Ao([_t()],Ar.prototype,"title",2);Ar=Ao([Tr("ti-taskitem")],Ar);const Qd=':host{display:block;height:100%}.container{display:grid;grid-template-columns:1fr 90px;grid-template-rows:40px minmax(0,1fr);grid-auto-columns:1fr;gap:0 var(--sl-spacing-x-small);grid-auto-rows:1fr;grid-auto-flow:row;grid-template-areas:"title-area control-area" "body-area body-area";height:100%}.container .title-area{grid-area:title-area;display:flex;align-items:center;padding:0 var(--sl-spacing-3x-small)}.container .title-area sl-input{width:100%}.container .title-area sl-input::part(base){border:none}.container .title-area sl-input::part(input){padding-left:var(--sl-spacing-2x-small);font-weight:700}.container .control-area{grid-area:control-area;display:flex;align-items:center;padding-right:var(--sl-spacing-medium)}.container .control-area sl-button{width:100%}.container .body-area{width:100%;grid-area:body-area;padding:0 var(--sl-spacing-3x-small)}.container .body-area .input-item{width:100%;margin-bottom:var(--sl-spacing-small)}.container .body-area .input-item .label{display:flex;align-items:center;font-size:var(--sl-font-size-small);color:var(--sl-color-neutral-500);margin-bottom:var(--sl-spacing-3x-small)}.container .body-area .input-item .label sl-icon{margin-right:var(--sl-spacing-2x-small)}.container .body-area .input-item .label .button-area{margin-left:auto}.container .body-area .input-item .label .button-area sl-icon-button{font-size:var(--sl-font-size-medium)}.container .body-area .input-item .label .button-area sl-icon-button::part(base){padding:0;padding-left:var(--sl-spacing-3x-small)}.container .body-area .input-item .label .button-area sl-icon-button.active{color:var(--sl-color-primary-600)}.container .body-area .contents{width:100%}';var Zd=Object.defineProperty,Jd=Object.getOwnPropertyDescriptor,gn=(t,r,o,i)=>{for(var l=i>1?void 0:i?Jd(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&Zd(r,o,l),l};Le("/");let lr=class extends ae{constructor(){super(),this.isMemberEditMode=!1,this.isCheckBoxEditMode=!1}connectedCallback(){super.connectedCallback()}disconnectedCallback(){super.disconnectedCallback()}async willUpdate(t){super.willUpdate(t),this.taskId!==void 0?this.taskData=await pn.getTaskById(this.taskId):this.taskData=void 0}render(){return this.taskId?X`<div class="container">
+      <div class="title-area">
+        \x3C!--タイトル-->
+        <sl-input
+          id="title"
+          placeholder="title..."
+          size="small"
+          value=${this.taskData?.title}
+        ></sl-input>
+      </div>
+      <div class="control-area">
+        \x3C!--コントロールボタン-->
+        <sl-button size="small" variant="primary">
+          <sl-icon
+            library="taskit"
+            name="play-circle-fill"
+            slot="prefix"
+          ></sl-icon>
+          開始
+        </sl-button>
+      </div>
+      <div class="body-area scrollable">
+        \x3C!--期限日-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="calendar"></sl-icon>
+            <span>期限日</span>
+          </div>
+          <sl-input
+            id="due-date"
+            placeholder="due date..."
+            size="small"
+            type="date"
+            value=${this.taskData?.dueDate}
+          >
+          </sl-input>
+        </div>
+        \x3C!--説明-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="chat-left-text"></sl-icon>
+            <span>説明</span>
+          </div>
+          <sl-textarea
+            id="description"
+            size="small"
+            resize="none"
+            rows="5"
+            placeholder="description..."
+          ></sl-textarea>
+        </div>
+        \x3C!--関係者-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="people"></sl-icon>
+            <span>関係者</span>
+            <div class="button-area">
+              <sl-tooltip content="Add">
+                <sl-icon-button
+                  library="taskit"
+                  name="plus-lg"
+                  @click=${this._handleClickAddMember}
+                ></sl-icon-button>
+              </sl-tooltip>
+              <sl-tooltip content="Edit">
+                <sl-icon-button
+                  library="taskit"
+                  name="pencil-square"
+                  class=${this.isMemberEditMode?"active":""}
+                  @click=${this._handleClickEditMember}
+                ></sl-icon-button>
+              </sl-tooltip>
+            </div>
+          </div>
+          <div id="member" class="contents">
+            <ti-members
+              .isEditMode=${this.isMemberEditMode}
+              .members=${this.taskData?.members||[]}
+              @ti-change-members=${this._handleChangeMembers}
+            ></ti-members>
+          </div>
+        </div>
+        \x3C!--チェックリスト-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="ui-checks-grid"></sl-icon>
+            <span>チェックリスト</span>
+            <div class="button-area">
+              <sl-tooltip content="Edit">
+                <sl-icon-button
+                  library="taskit"
+                  name="pencil-square"
+                  class=${this.isCheckBoxEditMode?"active":""}
+                  @click=${this._handleClickEditCheckBox}
+                ></sl-icon-button>
+              </sl-tooltip>
+            </div>
+          </div>
+          <div class="contents">
+            <ti-checkboxes
+              .isEditMode=${this.isCheckBoxEditMode}
+              .checkboxes=${this.taskData?.checkboxes||[]}
+            ></ti-checkboxes>
+          </div>
+        </div>
+        \x3C!--関連URL-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="globe"></sl-icon>
+            <span>関連URL</span>
+            <div class="button-area">
+              <sl-tooltip content="Add">
+                <sl-icon-button
+                  library="taskit"
+                  name="plus-lg"
+                ></sl-icon-button>
+              </sl-tooltip>
+            </div>
+          </div>
+          <div class="contents"></div>
+        </div>
+        \x3C!--関連フォルダ-->
+        <div class="input-item">
+          <div class="label">
+            <sl-icon library="taskit" name="folder"></sl-icon>
+            <span>関連フォルダ</span>
+            <div class="button-area">
+              <sl-tooltip content="Add">
+                <sl-icon-button
+                  library="taskit"
+                  name="plus-lg"
+                ></sl-icon-button>
+              </sl-tooltip>
+            </div>
+          </div>
+          <div class="contents"></div>
+        </div>
+      </div>
+    </div>`:X``}_updateTaskData(){this.taskData&&pn.updateTask(this.taskData)}_handleClickEditMember(){this.isMemberEditMode=!this.isMemberEditMode}_handleClickAddMember(){this.taskData&&(this.taskData&&!this.taskData.members&&(this.taskData.members=[]),this.taskData.members.push({div:"",name:"",tel:""}),this._updateTaskData())}_handleChangeMembers(t){this.taskData.members=t.detail,this.taskData?.members.length===0&&(this.isMemberEditMode=!1),this._updateTaskData()}_handleClickEditCheckBox(){this.isCheckBoxEditMode=!this.isCheckBoxEditMode}};lr.styles=[ct`
+      ${Ae(qa)}
+    `,ct`
+      ${Ae(Qd)}
+    `];gn([C({type:Number})],lr.prototype,"taskId",2);gn([_t()],lr.prototype,"taskData",2);gn([_t()],lr.prototype,"isMemberEditMode",2);gn([_t()],lr.prototype,"isCheckBoxEditMode",2);lr=gn([Tr("ti-task-data")],lr);const th="#root{width:100%}#root .member{width:100%;display:flex;gap:var(--sl-spacing-2x-small);margin-bottom:var(--sl-spacing-2x-small)}#root .member .member-item{flex-grow:1;min-width:0}#root .member .action-item sl-icon-button{font-size:var(--sl-font-size-small);color:var(--sl-color-danger-500)}#root .member .action-item sl-icon-button::part(base){padding-left:var(--sl-spacing-2x-small);padding-right:var(--sl-spacing-2x-small)}";var eh=Object.defineProperty,rh=Object.getOwnPropertyDescriptor,Ui=(t,r,o,i)=>{for(var l=i>1?void 0:i?rh(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&eh(r,o,l),l};Le("/");let fn=class extends ae{constructor(){super(),this.members=[],this.isEditMode=!1}connectedCallback(){super.connectedCallback()}disconnectedCallback(){super.disconnectedCallback()}willUpdate(t){super.willUpdate(t)}render(){return X`<div id="root">
+      ${this.members.map((t,r)=>X`
+          <div class="member">
+            <sl-input
+              value=${t.div}
+              size="small"
+              placeholder="div..."
+              class="member-item div"
+              @sl-change=${this._handleChangeMembers}
+            >
+              <sl-icon library="taskit" name="building" slot="suffix"></sl-icon>
+            </sl-input>
+            <sl-input
+              value=${t.name}
+              size="small"
+              placeholder="name..."
+              class="member-item name"
+              @sl-change=${this._handleChangeMembers}
+            >
+              <sl-icon
+                library="taskit"
+                name="person-circle"
+                slot="suffix"
+              ></sl-icon>
+            </sl-input>
+            <sl-input
+              value=${t.tel}
+              size="small"
+              placeholder="tell..."
+              class="member-item tel"
+              @sl-change=${this._handleChangeMembers}
+            >
+              <sl-icon library="taskit" name="telephone" slot="suffix"></sl-icon
+            ></sl-input>
+            ${this.isEditMode?X` <div class="action-item">
+                  <sl-tooltip content="Delete">
+                    <sl-icon-button
+                      library="taskit"
+                      name="dash-circle-fill"
+                      @click=${()=>this._handleDeleteMembers(r)}
+                    ></sl-icon-button
+                  ></sl-tooltip>
+                </div>`:""}
+          </div>
+        `)}
+    </div>`}_handleChangeMembers(){const r=Array.from(this.renderRoot.querySelectorAll(".member")).map(o=>{const i=l=>(o?.querySelector(l)).value;return{div:i(".div"),name:i(".name"),tel:i(".tel")}});Ti(this,"ti-change-members",{detail:r})}_handleDeleteMembers(t){this.members.splice(t,1),Ti(this,"ti-change-members",{detail:this.members})}};fn.styles=ct`
+    ${Ae(th)}
+  `;Ui([C({type:Array})],fn.prototype,"members",2);Ui([C({type:Boolean})],fn.prototype,"isEditMode",2);fn=Ui([Tr("ti-members")],fn);const nh="sl-textarea::part(textarea){font-family:monospace}";var oh=Object.defineProperty,ih=Object.getOwnPropertyDescriptor,So=(t,r,o,i)=>{for(var l=i>1?void 0:i?ih(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&oh(r,o,l),l};Le("/");let Sr=class extends ae{constructor(){super(),this.checkboxes=[],this.isEditMode=!1}connectedCallback(){super.connectedCallback()}disconnectedCallback(){super.disconnectedCallback()}willUpdate(t){super.willUpdate(t),t.get("isEditMode")===!0&&!this.isEditMode&&this.textarea&&this._handleSaveFromTextarea()}_handleSaveFromTextarea(){if(!this.textarea)return;const r=this.textarea.value.split(`
+`).map(o=>o.trim()).filter(o=>o!=="").map(o=>{const i=/^-\s*\[[xX]\]/.test(o);return{label:o.replace(/^-\s*\[[ xX]\]\s*/,""),isChecked:i}}).filter(o=>o.label!=="");console.log("パース後の配列:",r)}render(){return this.isEditMode?X`<sl-textarea
+        id="checkboxes-textarea"
+        resize="auto"
+        size="small"
+        value="${this._convertCheckboxesToText()}"
+        @keydown=${this._handleKeyDown}
+      ></sl-textarea>`:X``}_convertCheckboxesToText(){return this.checkboxes.length===0?"- [ ] ":""}async _handleKeyDown(t){if(t.key!=="Enter"||t.isComposing||!this.textarea)return;const r=this.textarea.input,o=r.selectionStart,i=r.selectionEnd,l=this.textarea.value,h=l.substring(0,o).split(`
+`).pop()||"",m=/^\s*- \[[ xX]\]/;if(h.match(m)){t.preventDefault();const O=`
+- [ ] `,D=l.substring(0,o)+O+l.substring(i);this.textarea.value=D,await this.textarea.updateComplete;const P=o+O.length;r.setSelectionRange(P,P),this.textarea.focus()}}};Sr.styles=ct`
+    ${Ae(nh)}
+  `;So([st("#checkboxes-textarea")],Sr.prototype,"textarea",2);So([C({type:Array})],Sr.prototype,"checkboxes",2);So([C({type:Boolean})],Sr.prototype,"isEditMode",2);Sr=So([Tr("ti-checkboxes")],Sr);var sh=Object.defineProperty,ah=Object.getOwnPropertyDescriptor,ja=(t,r,o,i)=>{for(var l=i>1?void 0:i?ah(r,o):r,c=t.length-1,h;c>=0;c--)(h=t[c])&&(l=(i?h(r,o,l):h(l))||l);return i&&l&&sh(r,o,l),l};Le("/");let ho=class extends ae{constructor(){super(),this.selectedTaskId=void 0,du("taskit",{resolver:t=>t in Hs?`data:image/svg+xml;utf8,${encodeURIComponent(Hs[t])}`:""})}connectedCallback(){super.connectedCallback()}disconnectedCallback(){super.disconnectedCallback()}willUpdate(t){super.willUpdate(t)}render(){return X`<div class="container">
+      <div class="header-area"></div>
+      <div class="menu-area">
+        <ti-tasklist
+          @ti-taskitem-click=${this._handleTiClickTaskItem}
+        ></ti-tasklist>
+      </div>
+      <div class="contents1-area">
+        <ti-task-data .taskId=${this.selectedTaskId}></ti-task-data>
+      </div>
+      <div class="contents2-area"></div>
+      <div class="footer-area"></div>
+    </div>`}_handleTiClickTaskItem(t){this.selectedTaskId=t.detail.taskId}};ho.styles=ct`
+    ${Ae(Iu)}
+  `;ja([_t()],ho.prototype,"selectedTaskId",2);ho=ja([Tr("taskit-app")],ho);</script>
+    <style rel="stylesheet" crossorigin>:root,:host,.sl-theme-light{color-scheme:light;--sl-color-gray-50: hsl(0 0% 97.5%);--sl-color-gray-100: hsl(240 4.8% 95.9%);--sl-color-gray-200: hsl(240 5.9% 90%);--sl-color-gray-300: hsl(240 4.9% 83.9%);--sl-color-gray-400: hsl(240 5% 64.9%);--sl-color-gray-500: hsl(240 3.8% 46.1%);--sl-color-gray-600: hsl(240 5.2% 33.9%);--sl-color-gray-700: hsl(240 5.3% 26.1%);--sl-color-gray-800: hsl(240 3.7% 15.9%);--sl-color-gray-900: hsl(240 5.9% 10%);--sl-color-gray-950: hsl(240 7.3% 8%);--sl-color-red-50: hsl(0 85.7% 97.3%);--sl-color-red-100: hsl(0 93.3% 94.1%);--sl-color-red-200: hsl(0 96.3% 89.4%);--sl-color-red-300: hsl(0 93.5% 81.8%);--sl-color-red-400: hsl(0 90.6% 70.8%);--sl-color-red-500: hsl(0 84.2% 60.2%);--sl-color-red-600: hsl(0 72.2% 50.6%);--sl-color-red-700: hsl(0 73.7% 41.8%);--sl-color-red-800: hsl(0 70% 35.3%);--sl-color-red-900: hsl(0 62.8% 30.6%);--sl-color-red-950: hsl(0 60% 19.6%);--sl-color-orange-50: hsl(33.3 100% 96.5%);--sl-color-orange-100: hsl(34.3 100% 91.8%);--sl-color-orange-200: hsl(32.1 97.7% 83.1%);--sl-color-orange-300: hsl(30.7 97.2% 72.4%);--sl-color-orange-400: hsl(27 96% 61%);--sl-color-orange-500: hsl(24.6 95% 53.1%);--sl-color-orange-600: hsl(20.5 90.2% 48.2%);--sl-color-orange-700: hsl(17.5 88.3% 40.4%);--sl-color-orange-800: hsl(15 79.1% 33.7%);--sl-color-orange-900: hsl(15.3 74.6% 27.8%);--sl-color-orange-950: hsl(15.2 69.1% 19%);--sl-color-amber-50: hsl(48 100% 96.1%);--sl-color-amber-100: hsl(48 96.5% 88.8%);--sl-color-amber-200: hsl(48 96.6% 76.7%);--sl-color-amber-300: hsl(45.9 96.7% 64.5%);--sl-color-amber-400: hsl(43.3 96.4% 56.3%);--sl-color-amber-500: hsl(37.7 92.1% 50.2%);--sl-color-amber-600: hsl(32.1 94.6% 43.7%);--sl-color-amber-700: hsl(26 90.5% 37.1%);--sl-color-amber-800: hsl(22.7 82.5% 31.4%);--sl-color-amber-900: hsl(21.7 77.8% 26.5%);--sl-color-amber-950: hsl(22.9 74.1% 16.7%);--sl-color-yellow-50: hsl(54.5 91.7% 95.3%);--sl-color-yellow-100: hsl(54.9 96.7% 88%);--sl-color-yellow-200: hsl(52.8 98.3% 76.9%);--sl-color-yellow-300: hsl(50.4 97.8% 63.5%);--sl-color-yellow-400: hsl(47.9 95.8% 53.1%);--sl-color-yellow-500: hsl(45.4 93.4% 47.5%);--sl-color-yellow-600: hsl(40.6 96.1% 40.4%);--sl-color-yellow-700: hsl(35.5 91.7% 32.9%);--sl-color-yellow-800: hsl(31.8 81% 28.8%);--sl-color-yellow-900: hsl(28.4 72.5% 25.7%);--sl-color-yellow-950: hsl(33.1 69% 13.9%);--sl-color-lime-50: hsl(78.3 92% 95.1%);--sl-color-lime-100: hsl(79.6 89.1% 89.2%);--sl-color-lime-200: hsl(80.9 88.5% 79.6%);--sl-color-lime-300: hsl(82 84.5% 67.1%);--sl-color-lime-400: hsl(82.7 78% 55.5%);--sl-color-lime-500: hsl(83.7 80.5% 44.3%);--sl-color-lime-600: hsl(84.8 85.2% 34.5%);--sl-color-lime-700: hsl(85.9 78.4% 27.3%);--sl-color-lime-800: hsl(86.3 69% 22.7%);--sl-color-lime-900: hsl(87.6 61.2% 20.2%);--sl-color-lime-950: hsl(86.5 60.6% 13.9%);--sl-color-green-50: hsl(138.5 76.5% 96.7%);--sl-color-green-100: hsl(140.6 84.2% 92.5%);--sl-color-green-200: hsl(141 78.9% 85.1%);--sl-color-green-300: hsl(141.7 76.6% 73.1%);--sl-color-green-400: hsl(141.9 69.2% 58%);--sl-color-green-500: hsl(142.1 70.6% 45.3%);--sl-color-green-600: hsl(142.1 76.2% 36.3%);--sl-color-green-700: hsl(142.4 71.8% 29.2%);--sl-color-green-800: hsl(142.8 64.2% 24.1%);--sl-color-green-900: hsl(143.8 61.2% 20.2%);--sl-color-green-950: hsl(144.3 60.7% 12%);--sl-color-emerald-50: hsl(151.8 81% 95.9%);--sl-color-emerald-100: hsl(149.3 80.4% 90%);--sl-color-emerald-200: hsl(152.4 76% 80.4%);--sl-color-emerald-300: hsl(156.2 71.6% 66.9%);--sl-color-emerald-400: hsl(158.1 64.4% 51.6%);--sl-color-emerald-500: hsl(160.1 84.1% 39.4%);--sl-color-emerald-600: hsl(161.4 93.5% 30.4%);--sl-color-emerald-700: hsl(162.9 93.5% 24.3%);--sl-color-emerald-800: hsl(163.1 88.1% 19.8%);--sl-color-emerald-900: hsl(164.2 85.7% 16.5%);--sl-color-emerald-950: hsl(164.3 87.5% 9.4%);--sl-color-teal-50: hsl(166.2 76.5% 96.7%);--sl-color-teal-100: hsl(167.2 85.5% 89.2%);--sl-color-teal-200: hsl(168.4 83.8% 78.2%);--sl-color-teal-300: hsl(170.6 76.9% 64.3%);--sl-color-teal-400: hsl(172.5 66% 50.4%);--sl-color-teal-500: hsl(173.4 80.4% 40%);--sl-color-teal-600: hsl(174.7 83.9% 31.6%);--sl-color-teal-700: hsl(175.3 77.4% 26.1%);--sl-color-teal-800: hsl(176.1 69.4% 21.8%);--sl-color-teal-900: hsl(175.9 60.8% 19%);--sl-color-teal-950: hsl(176.5 58.6% 11.4%);--sl-color-cyan-50: hsl(183.2 100% 96.3%);--sl-color-cyan-100: hsl(185.1 95.9% 90.4%);--sl-color-cyan-200: hsl(186.2 93.5% 81.8%);--sl-color-cyan-300: hsl(187 92.4% 69%);--sl-color-cyan-400: hsl(187.9 85.7% 53.3%);--sl-color-cyan-500: hsl(188.7 94.5% 42.7%);--sl-color-cyan-600: hsl(191.6 91.4% 36.5%);--sl-color-cyan-700: hsl(192.9 82.3% 31%);--sl-color-cyan-800: hsl(194.4 69.6% 27.1%);--sl-color-cyan-900: hsl(196.4 63.6% 23.7%);--sl-color-cyan-950: hsl(196.8 61% 16.1%);--sl-color-sky-50: hsl(204 100% 97.1%);--sl-color-sky-100: hsl(204 93.8% 93.7%);--sl-color-sky-200: hsl(200.6 94.4% 86.1%);--sl-color-sky-300: hsl(199.4 95.5% 73.9%);--sl-color-sky-400: hsl(198.4 93.2% 59.6%);--sl-color-sky-500: hsl(198.6 88.7% 48.4%);--sl-color-sky-600: hsl(200.4 98% 39.4%);--sl-color-sky-700: hsl(201.3 96.3% 32.2%);--sl-color-sky-800: hsl(201 90% 27.5%);--sl-color-sky-900: hsl(202 80.3% 23.9%);--sl-color-sky-950: hsl(202.3 73.8% 16.5%);--sl-color-blue-50: hsl(213.8 100% 96.9%);--sl-color-blue-100: hsl(214.3 94.6% 92.7%);--sl-color-blue-200: hsl(213.3 96.9% 87.3%);--sl-color-blue-300: hsl(211.7 96.4% 78.4%);--sl-color-blue-400: hsl(213.1 93.9% 67.8%);--sl-color-blue-500: hsl(217.2 91.2% 59.8%);--sl-color-blue-600: hsl(221.2 83.2% 53.3%);--sl-color-blue-700: hsl(224.3 76.3% 48%);--sl-color-blue-800: hsl(225.9 70.7% 40.2%);--sl-color-blue-900: hsl(224.4 64.3% 32.9%);--sl-color-blue-950: hsl(226.2 55.3% 18.4%);--sl-color-indigo-50: hsl(225.9 100% 96.7%);--sl-color-indigo-100: hsl(226.5 100% 93.9%);--sl-color-indigo-200: hsl(228 96.5% 88.8%);--sl-color-indigo-300: hsl(229.7 93.5% 81.8%);--sl-color-indigo-400: hsl(234.5 89.5% 73.9%);--sl-color-indigo-500: hsl(238.7 83.5% 66.7%);--sl-color-indigo-600: hsl(243.4 75.4% 58.6%);--sl-color-indigo-700: hsl(244.5 57.9% 50.6%);--sl-color-indigo-800: hsl(243.7 54.5% 41.4%);--sl-color-indigo-900: hsl(242.2 47.4% 34.3%);--sl-color-indigo-950: hsl(243.5 43.6% 22.9%);--sl-color-violet-50: hsl(250 100% 97.6%);--sl-color-violet-100: hsl(251.4 91.3% 95.5%);--sl-color-violet-200: hsl(250.5 95.2% 91.8%);--sl-color-violet-300: hsl(252.5 94.7% 85.1%);--sl-color-violet-400: hsl(255.1 91.7% 76.3%);--sl-color-violet-500: hsl(258.3 89.5% 66.3%);--sl-color-violet-600: hsl(262.1 83.3% 57.8%);--sl-color-violet-700: hsl(263.4 70% 50.4%);--sl-color-violet-800: hsl(263.4 69.3% 42.2%);--sl-color-violet-900: hsl(263.5 67.4% 34.9%);--sl-color-violet-950: hsl(265.1 61.5% 21.4%);--sl-color-purple-50: hsl(270 100% 98%);--sl-color-purple-100: hsl(268.7 100% 95.5%);--sl-color-purple-200: hsl(268.6 100% 91.8%);--sl-color-purple-300: hsl(269.2 97.4% 85.1%);--sl-color-purple-400: hsl(270 95.2% 75.3%);--sl-color-purple-500: hsl(270.7 91% 65.1%);--sl-color-purple-600: hsl(271.5 81.3% 55.9%);--sl-color-purple-700: hsl(272.1 71.7% 47.1%);--sl-color-purple-800: hsl(272.9 67.2% 39.4%);--sl-color-purple-900: hsl(273.6 65.6% 32%);--sl-color-purple-950: hsl(276 59.5% 16.5%);--sl-color-fuchsia-50: hsl(289.1 100% 97.8%);--sl-color-fuchsia-100: hsl(287 100% 95.5%);--sl-color-fuchsia-200: hsl(288.3 95.8% 90.6%);--sl-color-fuchsia-300: hsl(291.1 93.1% 82.9%);--sl-color-fuchsia-400: hsl(292 91.4% 72.5%);--sl-color-fuchsia-500: hsl(292.2 84.1% 60.6%);--sl-color-fuchsia-600: hsl(293.4 69.5% 48.8%);--sl-color-fuchsia-700: hsl(294.7 72.4% 39.8%);--sl-color-fuchsia-800: hsl(295.4 70.2% 32.9%);--sl-color-fuchsia-900: hsl(296.7 63.6% 28%);--sl-color-fuchsia-950: hsl(297.1 56.8% 14.5%);--sl-color-pink-50: hsl(327.3 73.3% 97.1%);--sl-color-pink-100: hsl(325.7 77.8% 94.7%);--sl-color-pink-200: hsl(325.9 84.6% 89.8%);--sl-color-pink-300: hsl(327.4 87.1% 81.8%);--sl-color-pink-400: hsl(328.6 85.5% 70.2%);--sl-color-pink-500: hsl(330.4 81.2% 60.4%);--sl-color-pink-600: hsl(333.3 71.4% 50.6%);--sl-color-pink-700: hsl(335.1 77.6% 42%);--sl-color-pink-800: hsl(335.8 74.4% 35.3%);--sl-color-pink-900: hsl(335.9 69% 30.4%);--sl-color-pink-950: hsl(336.2 65.4% 15.9%);--sl-color-rose-50: hsl(355.7 100% 97.3%);--sl-color-rose-100: hsl(355.6 100% 94.7%);--sl-color-rose-200: hsl(352.7 96.1% 90%);--sl-color-rose-300: hsl(352.6 95.7% 81.8%);--sl-color-rose-400: hsl(351.3 94.5% 71.4%);--sl-color-rose-500: hsl(349.7 89.2% 60.2%);--sl-color-rose-600: hsl(346.8 77.2% 49.8%);--sl-color-rose-700: hsl(345.3 82.7% 40.8%);--sl-color-rose-800: hsl(343.4 79.7% 34.7%);--sl-color-rose-900: hsl(341.5 75.5% 30.4%);--sl-color-rose-950: hsl(341.3 70.1% 17.1%);--sl-color-primary-50: var(--sl-color-sky-50);--sl-color-primary-100: var(--sl-color-sky-100);--sl-color-primary-200: var(--sl-color-sky-200);--sl-color-primary-300: var(--sl-color-sky-300);--sl-color-primary-400: var(--sl-color-sky-400);--sl-color-primary-500: var(--sl-color-sky-500);--sl-color-primary-600: var(--sl-color-sky-600);--sl-color-primary-700: var(--sl-color-sky-700);--sl-color-primary-800: var(--sl-color-sky-800);--sl-color-primary-900: var(--sl-color-sky-900);--sl-color-primary-950: var(--sl-color-sky-950);--sl-color-success-50: var(--sl-color-green-50);--sl-color-success-100: var(--sl-color-green-100);--sl-color-success-200: var(--sl-color-green-200);--sl-color-success-300: var(--sl-color-green-300);--sl-color-success-400: var(--sl-color-green-400);--sl-color-success-500: var(--sl-color-green-500);--sl-color-success-600: var(--sl-color-green-600);--sl-color-success-700: var(--sl-color-green-700);--sl-color-success-800: var(--sl-color-green-800);--sl-color-success-900: var(--sl-color-green-900);--sl-color-success-950: var(--sl-color-green-950);--sl-color-warning-50: var(--sl-color-amber-50);--sl-color-warning-100: var(--sl-color-amber-100);--sl-color-warning-200: var(--sl-color-amber-200);--sl-color-warning-300: var(--sl-color-amber-300);--sl-color-warning-400: var(--sl-color-amber-400);--sl-color-warning-500: var(--sl-color-amber-500);--sl-color-warning-600: var(--sl-color-amber-600);--sl-color-warning-700: var(--sl-color-amber-700);--sl-color-warning-800: var(--sl-color-amber-800);--sl-color-warning-900: var(--sl-color-amber-900);--sl-color-warning-950: var(--sl-color-amber-950);--sl-color-danger-50: var(--sl-color-red-50);--sl-color-danger-100: var(--sl-color-red-100);--sl-color-danger-200: var(--sl-color-red-200);--sl-color-danger-300: var(--sl-color-red-300);--sl-color-danger-400: var(--sl-color-red-400);--sl-color-danger-500: var(--sl-color-red-500);--sl-color-danger-600: var(--sl-color-red-600);--sl-color-danger-700: var(--sl-color-red-700);--sl-color-danger-800: var(--sl-color-red-800);--sl-color-danger-900: var(--sl-color-red-900);--sl-color-danger-950: var(--sl-color-red-950);--sl-color-neutral-50: var(--sl-color-gray-50);--sl-color-neutral-100: var(--sl-color-gray-100);--sl-color-neutral-200: var(--sl-color-gray-200);--sl-color-neutral-300: var(--sl-color-gray-300);--sl-color-neutral-400: var(--sl-color-gray-400);--sl-color-neutral-500: var(--sl-color-gray-500);--sl-color-neutral-600: var(--sl-color-gray-600);--sl-color-neutral-700: var(--sl-color-gray-700);--sl-color-neutral-800: var(--sl-color-gray-800);--sl-color-neutral-900: var(--sl-color-gray-900);--sl-color-neutral-950: var(--sl-color-gray-950);--sl-color-neutral-0: hsl(0, 0%, 100%);--sl-color-neutral-1000: hsl(0, 0%, 0%);--sl-border-radius-small: .1875rem;--sl-border-radius-medium: .25rem;--sl-border-radius-large: .5rem;--sl-border-radius-x-large: 1rem;--sl-border-radius-circle: 50%;--sl-border-radius-pill: 9999px;--sl-shadow-x-small: 0 1px 2px hsl(240 3.8% 46.1% / 6%);--sl-shadow-small: 0 1px 2px hsl(240 3.8% 46.1% / 12%);--sl-shadow-medium: 0 2px 4px hsl(240 3.8% 46.1% / 12%);--sl-shadow-large: 0 2px 8px hsl(240 3.8% 46.1% / 12%);--sl-shadow-x-large: 0 4px 16px hsl(240 3.8% 46.1% / 12%);--sl-spacing-3x-small: .125rem;--sl-spacing-2x-small: .25rem;--sl-spacing-x-small: .5rem;--sl-spacing-small: .75rem;--sl-spacing-medium: 1rem;--sl-spacing-large: 1.25rem;--sl-spacing-x-large: 1.75rem;--sl-spacing-2x-large: 2.25rem;--sl-spacing-3x-large: 3rem;--sl-spacing-4x-large: 4.5rem;--sl-transition-x-slow: 1s;--sl-transition-slow: .5s;--sl-transition-medium: .25s;--sl-transition-fast: .15s;--sl-transition-x-fast: 50ms;--sl-font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;--sl-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";--sl-font-serif: Georgia, "Times New Roman", serif;--sl-font-size-2x-small: .625rem;--sl-font-size-x-small: .75rem;--sl-font-size-small: .875rem;--sl-font-size-medium: 1rem;--sl-font-size-large: 1.25rem;--sl-font-size-x-large: 1.5rem;--sl-font-size-2x-large: 2.25rem;--sl-font-size-3x-large: 3rem;--sl-font-size-4x-large: 4.5rem;--sl-font-weight-light: 300;--sl-font-weight-normal: 400;--sl-font-weight-semibold: 500;--sl-font-weight-bold: 700;--sl-letter-spacing-denser: -.03em;--sl-letter-spacing-dense: -.015em;--sl-letter-spacing-normal: normal;--sl-letter-spacing-loose: .075em;--sl-letter-spacing-looser: .15em;--sl-line-height-denser: 1;--sl-line-height-dense: 1.4;--sl-line-height-normal: 1.8;--sl-line-height-loose: 2.2;--sl-line-height-looser: 2.6;--sl-focus-ring-color: var(--sl-color-primary-600);--sl-focus-ring-style: solid;--sl-focus-ring-width: 3px;--sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);--sl-focus-ring-offset: 1px;--sl-button-font-size-small: var(--sl-font-size-x-small);--sl-button-font-size-medium: var(--sl-font-size-small);--sl-button-font-size-large: var(--sl-font-size-medium);--sl-input-height-small: 1.875rem;--sl-input-height-medium: 2.5rem;--sl-input-height-large: 3.125rem;--sl-input-background-color: var(--sl-color-neutral-0);--sl-input-background-color-hover: var(--sl-input-background-color);--sl-input-background-color-focus: var(--sl-input-background-color);--sl-input-background-color-disabled: var(--sl-color-neutral-100);--sl-input-border-color: var(--sl-color-neutral-300);--sl-input-border-color-hover: var(--sl-color-neutral-400);--sl-input-border-color-focus: var(--sl-color-primary-500);--sl-input-border-color-disabled: var(--sl-color-neutral-300);--sl-input-border-width: 1px;--sl-input-required-content: "*";--sl-input-required-content-offset: -2px;--sl-input-required-content-color: var(--sl-input-label-color);--sl-input-border-radius-small: var(--sl-border-radius-medium);--sl-input-border-radius-medium: var(--sl-border-radius-medium);--sl-input-border-radius-large: var(--sl-border-radius-medium);--sl-input-font-family: var(--sl-font-sans);--sl-input-font-weight: var(--sl-font-weight-normal);--sl-input-font-size-small: var(--sl-font-size-small);--sl-input-font-size-medium: var(--sl-font-size-medium);--sl-input-font-size-large: var(--sl-font-size-large);--sl-input-letter-spacing: var(--sl-letter-spacing-normal);--sl-input-color: var(--sl-color-neutral-700);--sl-input-color-hover: var(--sl-color-neutral-700);--sl-input-color-focus: var(--sl-color-neutral-700);--sl-input-color-disabled: var(--sl-color-neutral-900);--sl-input-icon-color: var(--sl-color-neutral-500);--sl-input-icon-color-hover: var(--sl-color-neutral-600);--sl-input-icon-color-focus: var(--sl-color-neutral-600);--sl-input-placeholder-color: var(--sl-color-neutral-500);--sl-input-placeholder-color-disabled: var(--sl-color-neutral-600);--sl-input-spacing-small: var(--sl-spacing-small);--sl-input-spacing-medium: var(--sl-spacing-medium);--sl-input-spacing-large: var(--sl-spacing-large);--sl-input-focus-ring-color: hsl(198.6 88.7% 48.4% / 40%);--sl-input-focus-ring-offset: 0;--sl-input-filled-background-color: var(--sl-color-neutral-100);--sl-input-filled-background-color-hover: var(--sl-color-neutral-100);--sl-input-filled-background-color-focus: var(--sl-color-neutral-100);--sl-input-filled-background-color-disabled: var(--sl-color-neutral-100);--sl-input-filled-color: var(--sl-color-neutral-800);--sl-input-filled-color-hover: var(--sl-color-neutral-800);--sl-input-filled-color-focus: var(--sl-color-neutral-700);--sl-input-filled-color-disabled: var(--sl-color-neutral-800);--sl-input-label-font-size-small: var(--sl-font-size-small);--sl-input-label-font-size-medium: var(--sl-font-size-medium);--sl-input-label-font-size-large: var(--sl-font-size-large);--sl-input-label-color: inherit;--sl-input-help-text-font-size-small: var(--sl-font-size-x-small);--sl-input-help-text-font-size-medium: var(--sl-font-size-small);--sl-input-help-text-font-size-large: var(--sl-font-size-medium);--sl-input-help-text-color: var(--sl-color-neutral-500);--sl-toggle-size-small: .875rem;--sl-toggle-size-medium: 1.125rem;--sl-toggle-size-large: 1.375rem;--sl-overlay-background-color: hsl(240 3.8% 46.1% / 33%);--sl-panel-background-color: var(--sl-color-neutral-0);--sl-panel-border-color: var(--sl-color-neutral-200);--sl-panel-border-width: 1px;--sl-tooltip-border-radius: var(--sl-border-radius-medium);--sl-tooltip-background-color: var(--sl-color-neutral-800);--sl-tooltip-color: var(--sl-color-neutral-0);--sl-tooltip-font-family: var(--sl-font-sans);--sl-tooltip-font-weight: var(--sl-font-weight-normal);--sl-tooltip-font-size: var(--sl-font-size-small);--sl-tooltip-line-height: var(--sl-line-height-dense);--sl-tooltip-padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);--sl-tooltip-arrow-size: 6px;--sl-z-index-drawer: 700;--sl-z-index-dialog: 800;--sl-z-index-dropdown: 900;--sl-z-index-toast: 950;--sl-z-index-tooltip: 1000}@supports (scrollbar-gutter: stable){.sl-scroll-lock{scrollbar-gutter:var(--sl-scroll-lock-gutter)!important}.sl-scroll-lock body{overflow:hidden!important}}@supports not (scrollbar-gutter: stable){.sl-scroll-lock body{padding-right:var(--sl-scroll-lock-size)!important;overflow:hidden!important}}.sl-toast-stack{position:fixed;top:0;inset-inline-end:0;z-index:var(--sl-z-index-toast);width:28rem;max-width:100%;max-height:100%;overflow:auto}.sl-toast-stack sl-alert{margin:var(--sl-spacing-medium)}.sl-toast-stack sl-alert::part(base){box-shadow:var(--sl-shadow-large)}</style>
+  </head>
+  <body>
+    <taskit-app></taskit-app>
+  </body>
+</html>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export * from "@components/ti-tasklist/ti-tasklist";
 export * from "@components/ti-taskitem/ti-taskitem";
 export * from "@/components/ti-taskdata/ti-task-data";
 export * from "@/components/ti-members/ti-members";
+export * from "@/components/ti-checkboxes/ti-checkboxes";

--- a/src/components/ti-checkboxes/ti-checkboxes.lit.scss
+++ b/src/components/ti-checkboxes/ti-checkboxes.lit.scss
@@ -1,0 +1,34 @@
+sl-textarea {
+  &::part(textarea) {
+    font-family: monospace;
+  }
+}
+
+.checkbox-area {
+  width: 100%;
+
+  .checkbox-line {
+    width: 100%;
+
+    sl-checkbox {
+      width: 100%;
+      padding-left: 0 var(--sl-spacing-2x-small);
+
+      &:hover {
+        color: var(--sl-color-primary-600);
+      }
+
+      &::part(base) {
+        width: 100%;
+      }
+
+      &::part(label) {
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        padding-bottom: 2px;
+      }
+    }
+  }
+}

--- a/src/components/ti-checkboxes/ti-checkboxes.ts
+++ b/src/components/ti-checkboxes/ti-checkboxes.ts
@@ -1,0 +1,255 @@
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  PropertyValues,
+  HTMLTemplateResult,
+} from "lit";
+import { customElement, state, property, query } from "lit/decorators.js";
+import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
+import { emit } from "@/service/utils";
+import { CB } from "@/models/CB";
+
+import "@shoelace-style/shoelace/dist/themes/light.css";
+import styles from "./ti-checkboxes.lit.scss?inline";
+import { SlTextarea } from "@shoelace-style/shoelace";
+import { i } from "node_modules/vite/dist/node/chunks/moduleRunnerTransport";
+
+setBasePath("/");
+@customElement("ti-checkboxes")
+export class TiCheckboxes extends LitElement {
+  /**
+   * スタイルシートを適用
+   *
+   * @static
+   * @memberof TiCheckboxes
+   */
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  @query("#checkboxes-textarea") private textarea!: SlTextarea;
+
+  /**
+   * チェックボックスプロパティ
+   *
+   * @type {Member[]}
+   * @memberof TiCheckboxes
+   */
+  @property({ type: Array }) checkboxes: CB[] = [];
+
+  /**
+   * 編集モードかどうかを管理するフラグ
+   * @type {boolean}
+   * @memberof TiCheckboxes
+   */
+  @property({ type: Boolean }) isEditMode: boolean = false;
+
+  /**
+   * Creates an instance of TiCheckboxes.
+   * @memberof TiCheckboxes
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM に追加されたときに実行されます。
+   *
+   * @override
+   * @memberof TiCheckboxes
+   */
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM から削除されたときに実行されます。
+   *
+   * @override
+   * @memberof TiCheckboxes
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  /**
+   * render直前に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TiCheckboxes
+   */
+  protected willUpdate(_changedProperties: PropertyValues) {
+    super.willUpdate(_changedProperties);
+    if (_changedProperties.get("isEditMode") === true && !this.isEditMode) {
+      if (this.textarea) {
+        this._handleSaveFromTextarea();
+      }
+    }
+  }
+
+  /**
+   * Textareaの値を解析して checkboxes プロパティを更新する
+   */
+  private _handleSaveFromTextarea() {
+    if (!this.textarea) return;
+
+    const rawValue = this.textarea.value;
+
+    // 行ごとに分割してパース処理
+    const updateCheckboxes: CB[] = rawValue
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line !== "") // 空行を除外
+      .map((line) => {
+        // Markdownのチェックボックス構文を判定
+        // [x] または [X] なら true、それ以外（[ ] など）なら false
+        const isChecked = /^-\s*\[[xX]\]/.test(line);
+
+        // ラベル部分の抽出（"- [ ] " や "- [x] " の後ろの文字列を取得）
+        const label = line.replace(/^-\s*\[[ xX]\]\s*/, "");
+
+        return {
+          label: label,
+          isChecked: isChecked,
+        };
+      })
+      .filter((item) => item.label !== ""); // ラベルが空の項目を除外;
+
+    // 結果をコンソール出力
+    emit(this, "ti-change-checkboxes", { detail: updateCheckboxes });
+  }
+
+  /**
+   * コンポーネントのメインレイアウトをレンダリングします。
+   * アプリケーションの基本構造を定義します。
+   *
+   * @protected
+   * @override
+   * @returns {HTMLTemplateResult} レンダリングされる Lit テンプレート
+   * @memberof TiCheckboxes
+   */
+  protected render(): HTMLTemplateResult {
+    if (this.isEditMode) {
+      return html`<sl-textarea
+        id="checkboxes-textarea"
+        resize="auto"
+        size="small"
+        value="${this._convertCheckboxesToText()}"
+        @keydown=${this._handleKeyDown}
+      ></sl-textarea>`;
+    } else if (this.checkboxes.length > 0) {
+      return html`<div class="checkbox-area">
+        ${this.checkboxes.map((cb, index) => {
+          return html`<div class="checkbox-line">
+            <sl-checkbox
+              size="small"
+              ?checked=${cb.isChecked}
+              @sl-change=${(e: Event) => this._handleChangeChecked(e, index)}
+            >
+              ${cb.label}
+            </sl-checkbox>
+          </div>`;
+        })}
+      </div>`;
+    } else {
+      return html``;
+    }
+  }
+
+  /**
+   * checkboxes プロパティの内容を Markdown のチェックボックス構文に変換する
+   *
+   * @returns {string} Markdown形式のチェックボックスリスト
+   * @memberof TiCheckboxes
+   */
+  private _convertCheckboxesToText(): string {
+    if (this.checkboxes.length === 0) {
+      return "- [ ] ";
+    }
+    return this.checkboxes
+      .map((cv) => {
+        const checkboxSyntax = cv.isChecked ? "- [x] " : "- [ ] ";
+        return checkboxSyntax + cv.label;
+      })
+      .join("\n");
+  }
+
+  /**
+   * Enterキー押下時のチェックボックス自動挿入ハンドラ
+   * * 現在の行が Markdown のチェックボックス構文（- [ ] または - [x]）で
+   * 始まっている場合、改行後に新しい未チェックのボックスを自動挿入します。
+   *
+   * @private
+   * @param {KeyboardEvent} e - キーボードイベント
+   * @memberof TiCheckboxes
+   */
+  private async _handleKeyDown(e: KeyboardEvent) {
+    // Enterキー以外、またはIME（日本語入力など）の確定時のEnterは除外
+    if (e.key !== "Enter" || e.isComposing) {
+      return;
+    }
+
+    if (!this.textarea) {
+      return;
+    }
+
+    // Shoelace(sl-textarea) 内部のネイティブな textarea 要素にアクセス
+    const nativeTextarea = this.textarea.input as HTMLTextAreaElement;
+
+    // 現在の選択範囲（カーソル位置）とテキスト全体を取得
+    const start = nativeTextarea.selectionStart;
+    const end = nativeTextarea.selectionEnd;
+    const value = this.textarea.value;
+
+    // 文頭からカーソル位置までのテキストを切り出し、現在の行の内容を特定
+    const textBeforeCursor = value.substring(0, start);
+    const currentLine = textBeforeCursor.split("\n").pop() || "";
+
+    // チェックボックス構文（- [ ] または - [x]）にマッチするか確認
+    // ^\s* : 行頭の空白を許容 / [ xX] : 未チェックまたはチェック済みの両方に対応
+    const checkboxRegex = /^\s*- \[[ xX]\]/;
+    const match = currentLine.match(checkboxRegex);
+
+    if (match) {
+      // 標準の改行処理を抑制
+      e.preventDefault();
+
+      // 新しい行に挿入する文字列（常に未チェック状態のボックスを生成）
+      const insertText = "\n- [ ] ";
+
+      // カーソル位置を起点に、前後の文字列と新しいボックス構文を結合
+      const newValue =
+        value.substring(0, start) + insertText + value.substring(end);
+
+      // コンポーネントに新しい値を反映
+      this.textarea.value = newValue;
+
+      // Shoelace のレンダリング更新が完了するのを待機
+      // これを待つことで、以降の setSelectionRange が正しく動作する
+      await this.textarea.updateComplete;
+
+      // カーソルを新しく挿入された行の末尾へ移動
+      const newPos = start + insertText.length;
+      nativeTextarea.setSelectionRange(newPos, newPos);
+
+      // 入力を継続できるようフォーカスを当てる
+      this.textarea.focus();
+    }
+  }
+
+  /**
+   * チェックボックスの状態が変更されたときのハンドラ
+   * @private
+   * @param e
+   * @param index
+   */
+  private _handleChangeChecked(e: Event, index: number) {
+    const target = e.target as HTMLInputElement;
+    const updatedCheckboxes = [...this.checkboxes];
+    updatedCheckboxes[index].isChecked = target.checked;
+    emit(this, "ti-change-checkboxes", { detail: updatedCheckboxes });
+  }
+}

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -49,11 +49,20 @@ export class TiTaskData extends LitElement {
   @state() private taskData?: Task;
 
   /**
-   * 編集モードかどうかを管理するフラグ
+   * 関係者が編集モードかどうかを管理するフラグ
    * @type {boolean}
    * @memberof TiTaskData
    */
   @state() private isMemberEditMode: boolean = false;
+
+  /**
+   * チェックボックスが編集モードかどうかを管理するフラグ
+   *
+   * @private
+   * @type {boolean}
+   * @memberof TiTaskData
+   */
+  @state() private isCheckBoxEditMode: boolean = false;
 
   /**
    * Creates an instance of TiTaskData.
@@ -172,7 +181,7 @@ export class TiTaskData extends LitElement {
               <sl-tooltip content="Add">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-square"
+                  name="plus-lg"
                   @click=${this._handleClickAddMember}
                 ></sl-icon-button>
               </sl-tooltip>
@@ -200,15 +209,23 @@ export class TiTaskData extends LitElement {
             <sl-icon library="taskit" name="ui-checks-grid"></sl-icon>
             <span>チェックリスト</span>
             <div class="button-area">
-              <sl-tooltip content="Add">
+              <sl-tooltip content="Edit">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-square"
+                  name="pencil-square"
+                  class=${this.isCheckBoxEditMode ? "active" : ""}
+                  @click=${this._handleClickEditCheckBox}
                 ></sl-icon-button>
               </sl-tooltip>
             </div>
           </div>
-          <div class="contents"></div>
+          <div class="contents">
+            <ti-checkboxes
+              .isEditMode=${this.isCheckBoxEditMode}
+              .checkboxes=${this.taskData?.checkboxes || []}
+              @ti-change-checkboxes=${this._handleChangeCheckBoxes}
+            ></ti-checkboxes>
+          </div>
         </div>
         <!--関連URL-->
         <div class="input-item">
@@ -219,7 +236,7 @@ export class TiTaskData extends LitElement {
               <sl-tooltip content="Add">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-square"
+                  name="plus-lg"
                 ></sl-icon-button>
               </sl-tooltip>
             </div>
@@ -235,7 +252,7 @@ export class TiTaskData extends LitElement {
               <sl-tooltip content="Add">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-square"
+                  name="plus-lg"
                 ></sl-icon-button>
               </sl-tooltip>
             </div>
@@ -303,6 +320,32 @@ export class TiTaskData extends LitElement {
     this.taskData!.members = e.detail;
     if (this.taskData?.members.length === 0) {
       this.isMemberEditMode = false;
+    }
+    this._updateTaskData();
+  }
+
+  /**
+   * チェックボックスの編集モードを切り替える。
+   *
+   * @private
+   * @memberof TiTaskData
+   */
+  private _handleClickEditCheckBox() {
+    this.isCheckBoxEditMode = !this.isCheckBoxEditMode;
+  }
+
+  /**
+   * チェックボックスの変更入力を検知しDBを更新する。
+   *
+   * @private
+   * @memberof TiTaskData
+   * @param {CustomEvent} e - チェックボックスの変更イベント
+   * @returns {*}
+   **/
+  private _handleChangeCheckBoxes(e: CustomEvent) {
+    this.taskData!.checkboxes = e.detail;
+    if (this.taskData?.checkboxes.length === 0) {
+      this.isCheckBoxEditMode = false;
     }
     this._updateTaskData();
   }

--- a/src/models/CB.ts
+++ b/src/models/CB.ts
@@ -1,0 +1,4 @@
+export interface CB {
+  label: string;
+  isChecked: boolean;
+}

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,4 +1,5 @@
 import { Member } from "./Member";
+import { CB } from "./CB";
 
 export const TASK_STATUS = {
   PENDING: { code: "0", label: "未対応" },
@@ -14,6 +15,7 @@ export interface Task {
   status: TaskStatusCode;
   dueDate?: Date;
   members: Member[];
+  checkboxes: CB[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/plugins/shoelace.ts
+++ b/src/plugins/shoelace.ts
@@ -1,5 +1,6 @@
 import "@shoelace-style/shoelace/dist/components/button/button.js";
 import "@shoelace-style/shoelace/dist/components/button-group/button-group.js";
+import "@shoelace-style/shoelace/dist/components/checkbox/checkbox.js";
 import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
 import "@shoelace-style/shoelace/dist/components/divider/divider.js";
 import "@shoelace-style/shoelace/dist/components/icon/icon.js";

--- a/src/service/TaskItDB.ts
+++ b/src/service/TaskItDB.ts
@@ -1,6 +1,5 @@
 import Dexie, { Table } from "dexie";
 import { TASK_STATUS, type Task } from "@/models/Task";
-import { type Member } from "@/models/Member";
 
 export class TaskItDB extends Dexie {
   task!: Table<Task>;
@@ -29,6 +28,7 @@ export class TaskItDB extends Dexie {
       title: title,
       status: TASK_STATUS.PENDING.code, // デフォルトは '0'（未対応）
       members: [],
+      checkboxes: [],
       dueDate: undefined,
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
- 新しいコンポーネント `ti-checkboxes` を追加し、チェックボックスの管理機能を実装。
- `ti-checkboxes` コンポーネントのスタイルを `ti-checkboxes.lit.scss` に定義。
- `TiTaskData` コンポーネントにチェックボックスの編集モードを追加し、タスクデータにチェックボックスの状態を保存。
- `CB` インターフェースを新規作成し、チェックボックスのラベルと状態を管理。
- `Task` インターフェースにチェックボックスの配列を追加。
- Shoelace のチェックボックスコンポーネントをインポート。
- データベースに新しいタスクを作成する際にチェックボックスの初期値を設定。