### PR TITLE
feat: #19 説明欄の拡大ボタンを追加

### DIFF
--- a/src/assets/icons.ts
+++ b/src/assets/icons.ts
@@ -3,6 +3,8 @@ import check_square from "@assets/icons/check-square.svg?raw";
 import calendar from "@assets/icons/calendar.svg?raw";
 import cardText from "@assets/icons/card-text.svg?raw";
 import chatLeftText from "@assets/icons/chat-left-text.svg?raw";
+import chevronBarExpand from "@assets/icons/chevron-bar-expand.svg?raw";
+import chevronBarContract from "@assets/icons/chevron-bar-contract.svg?raw";
 import copy from "@assets/icons/copy.svg?raw";
 import dashCircleFill from "@assets/icons/dash-circle-fill.svg?raw";
 import exclamationSquareFill from "@assets/icons/exclamation-square-fill.svg?raw";
@@ -26,6 +28,8 @@ import chevron_right from "@assets/icons/chevron-right.svg?raw";
 export const icons: Record<string, string> = {
   building: building,
   "check-square": check_square,
+  "chevron-bar-expand": chevronBarExpand,
+  "chevron-bar-contract": chevronBarContract,
   calendar: calendar,
   "card-text": cardText,
   "chat-left-text": chatLeftText,

--- a/src/assets/icons/chevron-bar-contract.svg
+++ b/src/assets/icons/chevron-bar-contract.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-bar-contract" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M3.646 14.854a.5.5 0 0 0 .708 0L8 11.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708m0-13.708a.5.5 0 0 1 .708 0L8 4.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8"/>
+</svg>

--- a/src/assets/icons/chevron-bar-expand.svg
+++ b/src/assets/icons/chevron-bar-expand.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-bar-expand" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M3.646 10.146a.5.5 0 0 1 .708 0L8 13.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708m0-4.292a.5.5 0 0 0 .708 0L8 2.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8"/>
+</svg>

--- a/src/components/ti-taskdata/ti-task-data.lit.scss
+++ b/src/components/ti-taskdata/ti-task-data.lit.scss
@@ -68,6 +68,7 @@
 
         .button-area {
           margin-left: auto;
+          margin-right: 2px;
 
           sl-icon-button {
             font-size: var(--sl-font-size-medium);

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -1,6 +1,7 @@
 import {
   LitElement,
   html,
+  nothing,
   css,
   unsafeCSS,
   PropertyValues,
@@ -47,6 +48,15 @@ export class TiTaskData extends LitElement {
    * @memberof TiTaskData
    */
   @state() private taskData?: Task;
+
+  /**
+   * 説明欄が拡大表示モード化同化を管理するフラグ
+   *
+   * @private
+   * @type {boolean}
+   * @memberof TiTaskData
+   */
+  @state() private isDescriptionExpandMode: boolean = false;
 
   /**
    * 関係者が編集モードかどうかを管理するフラグ
@@ -163,12 +173,31 @@ export class TiTaskData extends LitElement {
           <div class="label">
             <sl-icon library="taskit" name="chat-left-text"></sl-icon>
             <span>説明</span>
+            <div class="button-area">
+              <sl-tooltip
+                content="${this.isDescriptionExpandMode
+                  ? "Contract"
+                  : "Expand"}"
+              >
+                <sl-icon-button
+                  library="taskit"
+                  name="${this.isDescriptionExpandMode
+                    ? "chevron-bar-contract"
+                    : "chevron-bar-expand"}"
+                  @click=${() => {
+                    this.isDescriptionExpandMode =
+                      !this.isDescriptionExpandMode;
+                  }}
+                ></sl-icon-button>
+              </sl-tooltip>
+            </div>
           </div>
           <sl-textarea
             id="description"
             size="small"
             resize="none"
-            rows="5"
+            rows=${this.isDescriptionExpandMode ? nothing : "3"}
+            resize=${this.isDescriptionExpandMode ? "auto" : "none"}
             placeholder="description..."
           ></sl-textarea>
         </div>


### PR DESCRIPTION
- icons.tsに拡大・縮小用のアイコンを追加
- ti-task-data.tsに説明欄の拡大表示モードを管理するフラグを追加
- ti-task-data.tsに説明欄の拡大・縮小ボタンを実装
- ti-task-data.lit.scssにボタンの右マージンを追加