### PR TITLE
feat: #12 リンクコンポーネントを追加し、タスクデータに関連URLとフォルダを管理する機能を実装

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "@components/ti-taskitem/ti-taskitem";
 export * from "@/components/ti-taskdata/ti-task-data";
 export * from "@/components/ti-members/ti-members";
 export * from "@/components/ti-checkboxes/ti-checkboxes";
+export * from "@/components/ti-link/ti-link";

--- a/src/components/ti-checkboxes/ti-checkboxes.lit.scss
+++ b/src/components/ti-checkboxes/ti-checkboxes.lit.scss
@@ -12,7 +12,6 @@ sl-textarea {
 
     sl-checkbox {
       width: 100%;
-      padding-left: 0 var(--sl-spacing-2x-small);
 
       &:hover {
         color: var(--sl-color-primary-600);

--- a/src/components/ti-link/ti-link.lit.scss
+++ b/src/components/ti-link/ti-link.lit.scss
@@ -1,0 +1,50 @@
+sl-textarea {
+  &::part(textarea) {
+    font-family: monospace;
+  }
+}
+
+#root {
+  width: 100%;
+  margin-top: var(--sl-spacing-2x-small);
+  font-size: var(--sl-font-size-x-small);
+
+  .link-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--sl--sl-spacing-2x-small);
+
+    color: var(--sl-color-primary-600);
+
+    border: 1px solid var(--sl-color-neutral-300);
+    border-radius: var(--sl-border-radius-medium);
+    padding: var(--sl-spacing-3x-small) 0;
+    margin-bottom: var(--sl-spacing-2x-small);
+
+    cursor: pointer;
+
+    sl-icon {
+      flex-shrink: 0;
+      color: var(--sl-color-primary-600);
+      padding-left: var(--sl-spacing-2x-small);
+    }
+
+    .link-label {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+
+      padding-left: var(--sl-spacing-2x-small);
+    }
+
+    &:hover {
+      color: white;
+      background-color: var(--sl-color-primary-600);
+
+      sl-icon {
+        color: white;
+      }
+    }
+  }
+}

--- a/src/components/ti-link/ti-link.ts
+++ b/src/components/ti-link/ti-link.ts
@@ -1,0 +1,179 @@
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  PropertyValues,
+  HTMLTemplateResult,
+} from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
+import { emit, toastSuccess } from "@/service/utils";
+import { Link } from "@/models/Link";
+
+import "@shoelace-style/shoelace/dist/themes/light.css";
+import styles from "./ti-link.lit.scss?inline";
+import { SlTextarea } from "@shoelace-style/shoelace";
+
+setBasePath("/");
+@customElement("ti-link")
+export class TiLink extends LitElement {
+  /**
+   * スタイルシートを適用
+   *
+   * @static
+   * @memberof TiLink
+   */
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  /**
+   * Markdown形式のリンクテキスト
+   *
+   * @type {Link[]}
+   * @memberof TiLink
+   */
+  @property({ type: Array }) links: Link[] = [];
+
+  /**
+   * 編集モードかどうかを管理するフラグ
+   * @type {boolean}
+   * @memberof TiCheckboxes
+   */
+  @property({ type: Boolean }) isEditMode: boolean = false;
+
+  @query("#links-textarea") private textarea!: SlTextarea;
+
+  /**
+   * Creates an instance of TiLink.
+   * @memberof TiLink
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM に追加されたときに実行されます。
+   *
+   * @override
+   * @memberof TiLink
+   */
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM から削除されたときに実行されます。
+   *
+   * @override
+   * @memberof TiLink
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  /**
+   * render直前に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TiLink
+   */
+  protected willUpdate(_changedProperties: PropertyValues) {
+    super.willUpdate(_changedProperties);
+    if (_changedProperties.get("isEditMode") === true && !this.isEditMode) {
+      if (this.textarea) {
+        this._handleSaveFromTextarea();
+      }
+    }
+  }
+
+  /**
+   * Textareaの値を解析して links プロパティを更新する
+   *
+   * @private
+   * @memberof TiLink
+   */
+  private _handleSaveFromTextarea(): void {
+    const updateLinks: Link[] = this._parseMarkdownLinks(this.textarea.value);
+    emit(this, "ti-change-links", { detail: updateLinks });
+  }
+
+  /**
+   * Markdown形式のテキストを解析して Link[] に変換する
+   *
+   * @private
+   * @param {string} text
+   * @returns {Link[]}
+   * @memberof TiLink
+   */
+  private _parseMarkdownLinks(text: string): Link[] {
+    const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+    return [...text.matchAll(linkPattern)].map((match) => ({
+      label: match[1],
+      path: match[2],
+    }));
+  }
+
+  /**
+   * コンポーネントのメインレイアウトをレンダリングします。
+   * アプリケーションの基本構造を定義します。
+   *
+   * @protected
+   * @override
+   * @returns {HTMLTemplateResult} レンダリングされる Lit テンプレート
+   * @memberof TiLink
+   */
+  protected render(): HTMLTemplateResult {
+    if (this.isEditMode) {
+      return html`<sl-textarea
+        id="links-textarea"
+        resize="auto"
+        size="small"
+        placeholder="e.g. [Google](https://www.google.com)"
+        .value=${this._convertLinksToMarkdown(this.links)}
+      ></sl-textarea>`;
+    } else if (this.links?.length > 0) {
+      return html` <div id="root">
+        ${this.links.map(
+        (link) =>
+          html`<div
+              class="link-item"
+              @click=${() => this._handleClickLink(link.path)}
+            >
+              <sl-icon library="taskit" name="copy"></sl-icon>
+              <div class="link-label">${link.label}</div>
+            </div>`,
+      )}
+      </div>`;
+    } else {
+      return html``;
+    }
+  }
+
+  /**
+   * Linkオブジェクトの配列をMarkdown形式のテキストに変換する
+   * @param links
+   * @returns Markdown形式のテキスト
+   * @private
+   */
+  private _convertLinksToMarkdown(links: Link[]): string {
+    return links.map((link) => `[${link.label}](${link.path})`).join("\n");
+  }
+
+  /**
+   * クリックしたリンクのpathをクリップボードにコピーする
+   * @param path
+   * @private
+   * @memberof TiLink
+   */
+  private async _handleClickLink(path: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(path);
+      toastSuccess("coped", path);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  }
+}

--- a/src/components/ti-taskdata/ti-task-data.lit.scss
+++ b/src/components/ti-taskdata/ti-task-data.lit.scss
@@ -72,6 +72,7 @@
 
           sl-icon-button {
             font-size: var(--sl-font-size-medium);
+            color: var(--sl-color-neutral-400);
             &::part(base) {
               padding: 0;
               padding-left: var(--sl-spacing-3x-small);

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -77,6 +77,24 @@ export class TiTaskData extends LitElement {
   @state() private isCheckBoxEditMode: boolean = false;
 
   /**
+   * URLが編集モードかどうかを管理するフラグ
+   *
+   * @private
+   * @type {boolean}
+   * @memberof TiTaskData
+   */
+  @state() private isUrlEditMode: boolean = false;
+
+  /**
+   * フォルダが編集モードかどうかを管理するフラグ
+   *
+   * @private
+   * @type {boolean}
+   * @memberof TiTaskData
+   */
+  @state() private isFolderEditMode: boolean = false;
+
+  /**
    *タイトル入力フィールドの参照を取得するためのクエリデコレーター
    *
    * @private
@@ -140,10 +158,12 @@ export class TiTaskData extends LitElement {
    */
   protected async willUpdate(_changedProperties: PropertyValues) {
     super.willUpdate(_changedProperties);
-    if (this.taskId !== undefined) {
-      this.taskData = await db.getTaskById(this.taskId);
-    } else {
-      this.taskData = undefined;
+    if (_changedProperties.has("taskId")) {
+      if (this.taskId !== undefined) {
+        this.taskData = await db.getTaskById(this.taskId);
+      } else {
+        this.taskData = undefined;
+      }
     }
   }
 
@@ -295,15 +315,24 @@ export class TiTaskData extends LitElement {
             <sl-icon library="taskit" name="globe"></sl-icon>
             <span>関連URL</span>
             <div class="button-area">
-              <sl-tooltip content="Add">
+              <sl-tooltip content="Edit">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-lg"
+                  name="pencil-square"
+                  class=${this.isUrlEditMode ? "active" : ""}
+                  @click=${this._handleClickEditUrl}
                 ></sl-icon-button>
               </sl-tooltip>
             </div>
           </div>
-          <div class="contents"></div>
+          <div class="contents">
+            <ti-link
+              .isEditMode=${this.isUrlEditMode}
+              .links=${this.taskData?.urls ?? []}
+              @ti-change-links=${this._handleChangeUrl}
+            >
+            </ti-link>
+          </div>
         </div>
         <!--関連フォルダ-->
         <div class="input-item">
@@ -311,15 +340,24 @@ export class TiTaskData extends LitElement {
             <sl-icon library="taskit" name="folder"></sl-icon>
             <span>関連フォルダ</span>
             <div class="button-area">
-              <sl-tooltip content="Add">
+              <sl-tooltip content="Edit">
                 <sl-icon-button
                   library="taskit"
-                  name="plus-lg"
+                  name="pencil-square"
+                  class=${this.isFolderEditMode ? "active" : ""}
+                  @click=${this._handleClickEditFolder}
                 ></sl-icon-button>
               </sl-tooltip>
             </div>
           </div>
-          <div class="contents"></div>
+          <div class="contents">
+            <ti-link
+              .isEditMode=${this.isFolderEditMode}
+              .links=${this.taskData?.folders ?? []}
+              @ti-change-links=${this._handleChangeFolder}
+            >
+            </ti-link>
+          </div>
         </div>
       </div>
     </div>`;
@@ -381,11 +419,12 @@ export class TiTaskData extends LitElement {
    * @return {*}
    * @memberof TiTaskData
    */
-  private _updateTaskData(): void {
+  private async _updateTaskData(): Promise<void> {
     if (!this.taskData) {
       return;
     }
     db.updateTask(this.taskData);
+    this.taskData = await db.getTaskById(this.taskData.id!);
   }
 
   /**
@@ -457,6 +496,58 @@ export class TiTaskData extends LitElement {
     this.taskData!.checkboxes = e.detail;
     if (this.taskData?.checkboxes.length === 0) {
       this.isCheckBoxEditMode = false;
+    }
+    this._updateTaskData();
+  }
+
+  /**
+   * URLの編集モードを切り替える。
+   *
+   * @private
+   * @memberof TiTaskData
+   * @returns {*}
+   */
+  private _handleClickEditUrl(): void {
+    this.isUrlEditMode = !this.isUrlEditMode;
+  }
+
+  /**
+   * URLの変更入力を検知しDBを更新する。
+   * @param e
+   * @private
+   * @memberof TiTaskData
+   * @return {*}
+   */
+  private _handleChangeUrl(e: CustomEvent): void {
+    this.taskData!.urls = e.detail;
+    if (this.taskData?.urls.length === 0) {
+      this.isUrlEditMode = false;
+    }
+    this._updateTaskData();
+  }
+
+  /**
+   * フォルダの編集モードを切り替える。
+   *
+   * @private
+   * @memberof TiTaskData
+   * @returns {*}
+   */
+  private _handleClickEditFolder(): void {
+    this.isFolderEditMode = !this.isFolderEditMode;
+  }
+
+  /**
+   * フォルダの変更入力を検知しDBを更新する。
+   * @param e
+   * @private
+   * @memberof TiTaskData
+   * @return {*}
+   */
+  private _handleChangeFolder(e: CustomEvent): void {
+    this.taskData!.folders = e.detail;
+    if (this.taskData?.folders.length === 0) {
+      this.isFolderEditMode = false;
     }
     this._updateTaskData();
   }

--- a/src/models/Link.ts
+++ b/src/models/Link.ts
@@ -1,0 +1,4 @@
+export interface Link {
+  label: string;
+  path: string;
+}

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,5 +1,6 @@
 import { Member } from "./Member";
 import { CB } from "./CB";
+import { Link } from "./Link";
 
 export const TASK_STATUS = {
   PENDING: { code: "0", label: "未対応" },
@@ -11,12 +12,14 @@ type TaskStatusCode = (typeof TASK_STATUS)[keyof typeof TASK_STATUS]["code"];
 
 export interface Task {
   id?: number;
+  status: TaskStatusCode;
   title: string;
   description: string;
-  status: TaskStatusCode;
   dueDate?: Date;
   members: Member[];
   checkboxes: CB[];
+  urls: Link[];
+  folders: Link[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/plugins/shoelace.ts
+++ b/src/plugins/shoelace.ts
@@ -1,3 +1,4 @@
+import "@shoelace-style/shoelace/dist/components/alert/alert.js";
 import "@shoelace-style/shoelace/dist/components/button/button.js";
 import "@shoelace-style/shoelace/dist/components/button-group/button-group.js";
 import "@shoelace-style/shoelace/dist/components/checkbox/checkbox.js";

--- a/src/service/TaskItDB.ts
+++ b/src/service/TaskItDB.ts
@@ -25,12 +25,14 @@ export class TaskItDB extends Dexie {
 
     // Task インターフェースに基づいたオブジェクトを作成
     const newTask: Task = {
-      title: title,
       status: TASK_STATUS.PENDING.code, // デフォルトは '0'（未対応）
+      title: title,
       description: "",
+      dueDate: undefined,
       members: [],
       checkboxes: [],
-      dueDate: undefined,
+      urls: [],
+      folders: [],
       createdAt: now,
       updatedAt: now,
     };

--- a/src/service/utils.ts
+++ b/src/service/utils.ts
@@ -1,3 +1,5 @@
+import type { SlAlert } from "@shoelace-style/shoelace";
+
 /**
  * 日付オブジェクトを指定されたフォーマットの文字列に変換します。
  * * 使用可能なトークン: yyyy, MM, dd, HH, mm, ss
@@ -61,4 +63,54 @@ export function emit(el: HTMLElement, name: string, options?: CustomEventInit) {
 
   el.dispatchEvent(event);
   return event;
+}
+
+/**
+ * トースト通知を表示するためのベースとなる共通処理です。
+ *
+ * @param {string} variant 種類 ("success" | "danger" | "primary" など)
+ * @param {string} iconName 表示するアイコンの名前
+ * @param {string} title タイトル
+ * @param {string} message メッセージ内容
+ */
+function showToast(
+  variant: string,
+  iconName: string,
+  title: string,
+  message: string,
+) {
+  const alert = Object.assign(document.createElement("sl-alert"), {
+    variant: variant,
+    duration: 1500,
+    closable: true,
+    innerHTML: `
+        <sl-icon slot="icon" library="fillgo" name="${iconName}"></sl-icon>
+        <strong>${title}</strong><br />
+        ${message}
+      `,
+  });
+  document.body.append(alert);
+  (alert as SlAlert).toast();
+}
+
+/**
+ * 処理成功時のトーストを表示します。
+ *
+ * @export
+ * @param {string} innerTitleText タイトル
+ * @param {string} innerHtmlText メッセージ内容
+ */
+export function toastSuccess(innerTitleText: string, innerHtmlText: string) {
+  showToast("success", "check2-circle", innerTitleText, innerHtmlText);
+}
+
+/**
+ * 処理失敗時のトーストを表示します。
+ *
+ * @export
+ * @param {string} innerTitleText タイトル
+ * @param {string} innerHtmlText メッセージ内容
+ */
+export function toastDanger(innerTitleText: string, innerHtmlText: string) {
+  showToast("danger", "exclamation-octagon", innerTitleText, innerHtmlText);
 }


### PR DESCRIPTION
- ti-linkコンポーネントを新規作成し、Markdown形式のリンクを管理
- タスクデータモデルにurlsとfoldersプロパティを追加
- タスクデータコンポーネントに関連URLとフォルダの編集機能を追加
- スタイルシートを整備し、リンクコンポーネントの見た目を改善
- utils.tsにトースト通知機能を追加