### PR TITLE
feat: #48 タスクデータコンポーネントのレイアウトを変更

### DIFF
--- a/src/components/ti-taskdata/ti-task-data.lit.scss
+++ b/src/components/ti-taskdata/ti-task-data.lit.scss
@@ -6,13 +6,62 @@
 .container {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr;
+  grid-template-rows: 50px 1fr;
   grid-auto-columns: 1fr;
   grid-auto-rows: 1fr;
   grid-auto-flow: row;
-  gap: 0 var(--sl-spacing-x-small);
-  grid-template-areas: "main-area sub-area";
+  gap: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+  grid-template-areas: "header-area control-area" "main-area sub-area";
   height: 100%;
+
+  .header-area {
+    grid-area: header-area;
+
+    .title {
+      padding: 0 var(--sl-spacing-3x-small);
+      display: flex;
+      flex-direction: row;
+      align-items: flex-end;
+      gap: 5px;
+
+      sl-input {
+        flex: 1 1 auto;
+        width: 100%;
+
+        &::part(base) {
+          border: none;
+          box-shadow: none;
+        }
+
+        &::part(input) {
+          padding: var(--sl-spacing-2x-small);
+          margin-top: 5px;
+          height: 45px;
+          font-size: var(--sl-font-size-2x-large);
+          font-weight: bold;
+        }
+      }
+
+      sl-button {
+        flex: 0 0 90px;
+
+        width: 90px;
+      }
+    }
+  }
+
+  .control-area {
+    grid-area: control-area;
+    background-color: burlywood;
+  }
+
+  .main-area {
+    grid-area: main-area;
+  }
+
+  .sub-area {
+    grid-area: sub-area;
+  }
 
   .base {
     height: 100%;
@@ -61,33 +110,6 @@
               margin-top: var(--sl-spacing-2x-small);
             }
 
-            &.title {
-              margin-top: var(--sl-spacing-2x-small);
-              display: flex;
-              flex-direction: row;
-              gap: 5px;
-              align-items: center;
-
-              sl-input {
-                flex: 1 1 auto;
-                width: 100%;
-
-                &::part(base) {
-                  border: none;
-                }
-
-                &::part(input) {
-                  padding-left: var(--sl-spacing-2x-small);
-                  font-weight: bold;
-                }
-              }
-
-              sl-button {
-                flex: 0 0 90px;
-                width: 90px;
-              }
-            }
-
             .label {
               display: flex;
               align-items: center;
@@ -123,13 +145,5 @@
         }
       }
     }
-  }
-
-  .main-area {
-    grid-area: main-area;
-  }
-
-  .sub-area {
-    grid-area: sub-area;
   }
 }

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -187,6 +187,29 @@ export class TiTaskData extends LitElement {
       return html``;
     }
     return html`<div class="container">
+      <!--タイトル-->
+      <div class="header-area">
+        <div class="title">
+          <sl-input
+            id="title"
+            class="title-item"
+            placeholder="title..."
+            size="large"
+            value=${this._taskData?.title}
+            @sl-change=${this._handleChangeTitle}
+          ></sl-input>
+          <sl-button size="medium" variant="primary" class="title-item">
+            <sl-icon
+              library="taskit"
+              name="play-circle-fill"
+              slot="prefix"
+            ></sl-icon>
+            開始
+          </sl-button>
+        </div>
+      </div>
+      <!--コントロールボタン-->
+      <div class="control-area"></div>
       <div class="base main-area">
         <sl-tab-group>
           <sl-tab slot="nav" panel="summary">
@@ -204,25 +227,6 @@ export class TiTaskData extends LitElement {
 
           <sl-tab-panel name="summary">
             <div class="panel-contents scrollable">
-              <!--タイトル,コントロールボタン-->
-              <div class="input-item title">
-                <sl-input
-                  id="title"
-                  class="title-item"
-                  placeholder="title..."
-                  size="small"
-                  value=${this._taskData?.title}
-                  @sl-change=${this._handleChangeTitle}
-                ></sl-input>
-                <sl-button size="small" variant="primary" class="title-item">
-                  <sl-icon
-                    library="taskit"
-                    name="play-circle-fill"
-                    slot="prefix"
-                  ></sl-icon>
-                  開始
-                </sl-button>
-              </div>
               <!--期限日-->
               <div class="input-item">
                 <ti-input-label
@@ -289,14 +293,14 @@ export class TiTaskData extends LitElement {
                 ></ti-input-label>
                 <div class="contents">
                   ${this._taskData?.checklist.map((c, index) => {
-      return html`<ti-checkboxes
+                    return html`<ti-checkboxes
                       .label=${c.label}
                       .checkboxes=${c.checkboxes}
                       .isEditMode=${this._isCheckBoxEditMode}
                       @ti-change-checkboxes=${(e: CustomEvent) =>
-          this._saveCheckBoxes(e, index)}
+                        this._saveCheckBoxes(e, index)}
                     ></ti-checkboxes>`;
-    })}
+                  })}
                 </div>
               </div>
             </div>

--- a/src/components/ti-tasklist/ti-tasklist.ts
+++ b/src/components/ti-tasklist/ti-tasklist.ts
@@ -144,50 +144,50 @@ export class TiTaskList extends LitElement {
       <sl-tab-group>
         <sl-tab slot="nav" panel="pending">
           <sl-icon library="taskit" name="square"></sl-icon>
-          <span>未対応</span>
+          <span>未着手</span>
         </sl-tab>
         <sl-tab slot="nav" panel="progress">
           <sl-icon library="taskit" name="square-half"></sl-icon>
-          <span>対応中</span>
+          <span>実行中</span>
         </sl-tab>
         <sl-tab slot="nav" panel="done">
           <sl-icon library="taskit" name="check-square"></sl-icon>
-          <span>対応済</span>
+          <span>完了</span>
         </sl-tab>
 
         <sl-tab-panel name="pending">
           <div class="task-list scrollable">
             ${repeat(
-      this._pendingTasks,
-      (task) => task.id,
-      (task) => html`
+              this._pendingTasks,
+              (task) => task.id,
+              (task) => html`
                 <ti-taskitem .taskId=${task.id} .dueDate=${task.dueDate}>
                   ${task.title}
                 </ti-taskitem>
               `,
-    )}
+            )}
           </div>
         </sl-tab-panel>
         <sl-tab-panel name="progress">
           <div class="task-list scrollable">
             ${repeat(
-      this._progressTasks,
-      (task) => task.id,
-      (task) => html`
+              this._progressTasks,
+              (task) => task.id,
+              (task) => html`
                 <ti-taskitem .task=${task}>${task.title}</ti-taskitem>
               `,
-    )}
+            )}
           </div>
         </sl-tab-panel>
         <sl-tab-panel name="done">
           <div class="task-list scrollable">
             ${repeat(
-      this._doneTasks,
-      (task) => task.id,
-      (task) => html`
+              this._doneTasks,
+              (task) => task.id,
+              (task) => html`
                 <ti-taskitem .task=${task}>${task.title}</ti-taskitem>
               `,
-    )}
+            )}
           </div>
         </sl-tab-panel>
       </sl-tab-group>

--- a/src/taskit-app.lit.scss
+++ b/src/taskit-app.lit.scss
@@ -1,13 +1,13 @@
 .container {
   display: grid;
   grid-template-columns: 320px 1fr;
-  grid-template-rows: 40px minmax(0, 1fr) 20px;
+  grid-template-rows: 50px minmax(0, 1fr) 20px;
   grid-auto-columns: 1fr;
   grid-auto-rows: 1fr;
   gap: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
   grid-auto-flow: row;
   grid-template-areas:
-    "header-area header-area "
+    "header-area contents1-area "
     "menu-area contents1-area "
     "footer-area footer-area ";
   height: 100vh;
@@ -25,6 +25,8 @@
   .contents1-area {
     grid-area: contents1-area;
     overflow: hidden;
+    border-left: 1px solid var(--sl-color-neutral-200);
+    padding-left: var(--sl-spacing-x-small);
   }
 
   .footer-area {


### PR DESCRIPTION
- ti-task-data.lit.scss: グリッドレイアウトを更新し、ヘッダーエリアとコントロールエリアを追加
- ti-task-data.ts: タイトル入力とコントロールボタンをヘッダーエリアに移動
- ti-tasklist.ts: タブのラベルを日本語に変更
- taskit-app.lit.scss: コンテナの行の高さを調整し、コンテンツエリアにスタイルを追加