### PR TITLE
feat: #29 タスクコントロールボタンコンポーネントを追加

### DIFF
--- a/src/assets/icons.ts
+++ b/src/assets/icons.ts
@@ -1,9 +1,11 @@
+import arrowClockwise from "@assets/icons/arrow-clockwise.svg?raw";
 import building from "@assets/icons/building.svg?raw";
 import checkLg from "@assets/icons/check-lg.svg?raw";
 import check_square from "@assets/icons/check-square.svg?raw";
 import calendar from "@assets/icons/calendar.svg?raw";
 import cardText from "@assets/icons/card-text.svg?raw";
 import chatLeftText from "@assets/icons/chat-left-text.svg?raw";
+import checkCircleFill from "@assets/icons/check-circle-fill.svg?raw";
 import chevronBarExpand from "@assets/icons/chevron-bar-expand.svg?raw";
 import chevronBarContract from "@assets/icons/chevron-bar-contract.svg?raw";
 import copy from "@assets/icons/copy.svg?raw";
@@ -21,15 +23,18 @@ import plus_lg from "@assets/icons/plus-lg.svg?raw";
 import plusSquare from "@assets/icons/plus-square.svg?raw";
 import square from "@assets/icons/square.svg?raw";
 import square_half from "@assets/icons/square-half.svg?raw";
+import slashCircleFill from "@assets/icons/slash-circle-fill.svg?raw";
 import telephone from "@assets/icons/telephone.svg?raw";
 import trash3 from "@assets/icons/trash3.svg?raw";
 import uiChecksGrid from "@assets/icons/ui-checks-grid.svg?raw";
 import chevron_right from "@assets/icons/chevron-right.svg?raw";
 
 export const icons: Record<string, string> = {
+  "arrow-clockwise": arrowClockwise,
   building: building,
   "check-lg": checkLg,
   "check-square": check_square,
+  "check-circle-fill": checkCircleFill,
   "chevron-bar-expand": chevronBarExpand,
   "chevron-bar-contract": chevronBarContract,
   calendar: calendar,
@@ -50,6 +55,7 @@ export const icons: Record<string, string> = {
   "plus-square": plusSquare,
   square: square,
   "square-half": square_half,
+  "slash-circle-fill": slashCircleFill,
   telephone: telephone,
   trash3: trash3,
   "ui-checks-grid": uiChecksGrid,

--- a/src/assets/icons/arrow-clockwise.svg
+++ b/src/assets/icons/arrow-clockwise.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z"/>
+  <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466"/>
+</svg>

--- a/src/assets/icons/check-circle-fill.svg
+++ b/src/assets/icons/check-circle-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle-fill" viewBox="0 0 16 16">
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+</svg>

--- a/src/assets/icons/slash-circle-fill.svg
+++ b/src/assets/icons/slash-circle-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-slash-circle-fill" viewBox="0 0 16 16">
+  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.646-2.646a.5.5 0 0 0-.708-.708l-6 6a.5.5 0 0 0 .708.708z"/>
+</svg>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export * from "@/components/ti-members/ti-members";
 export * from "@/components/ti-checkboxes/ti-checkboxes";
 export * from "@/components/ti-link/ti-link";
 export * from "@/components/ti-input-label/ti-input-label";
+export * from "@/components/ti-status-button/ti-status-button";

--- a/src/components/ti-status-button/ti-status-button.lit.scss
+++ b/src/components/ti-status-button/ti-status-button.lit.scss
@@ -1,0 +1,3 @@
+#status-button {
+  width: 100px;
+}

--- a/src/components/ti-status-button/ti-status-button.ts
+++ b/src/components/ti-status-button/ti-status-button.ts
@@ -1,0 +1,223 @@
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  PropertyValues,
+  HTMLTemplateResult,
+} from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
+import { TASK_STATUS } from "@/models/Task";
+import { emit } from "@/service/utils";
+
+import "@shoelace-style/shoelace/dist/themes/light.css";
+import styles from "./ti-status-button.lit.scss?inline";
+
+/**
+ * UI表示に必要なパラメータの型定義
+ */
+interface ObjectParameter {
+  /** ボタンやバッジのスタイル指定（CSSクラス等に使用） */
+  variant: string;
+  /** 画面に表示するテキスト */
+  label: string;
+  /** アイコンフォントのクラス名や識別子 */
+  icon: string;
+}
+
+setBasePath("/");
+@customElement("ti-status-button")
+export class TiStatusButton extends LitElement {
+  /**
+   * スタイルシートを適用
+   *
+   * @static
+   * @memberof TiStatusButton
+   */
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  /**
+   * タスクのステータス
+   *
+   * @type {string}
+   * @memberof TiStatusButton
+   */
+  @property({ type: String }) status: string = TASK_STATUS.PENDING.code;
+
+  /**
+   * 完了状態
+   *
+   * @private
+   * @type {boolean}
+   * @memberof TiStatusButton
+   */
+  private _isDone: boolean = false;
+
+  /**
+   * Creates an instance of TiStatusButton.
+   * @memberof TiStatusButton
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM に追加されたときに実行されます。
+   *
+   * @override
+   * @memberof TiStatusButton
+   */
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM から削除されたときに実行されます。
+   *
+   * @override
+   * @memberof TiStatusButton
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  /**
+   * render直前に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TiStatusButton
+   */
+  protected willUpdate(_changedProperties: PropertyValues) {
+    super.willUpdate(_changedProperties);
+    if (_changedProperties.has("status")) {
+      this._isDone = this.status === TASK_STATUS.DONE.code;
+    }
+  }
+
+  /**
+   * コンポーネントのメインレイアウトをレンダリングします。
+   * アプリケーションの基本構造を定義します。
+   *
+   * @protected
+   * @override
+   * @returns {HTMLTemplateResult} レンダリングされる Lit テンプレート
+   * @memberof TiStatusButton
+   */
+  protected render(): HTMLTemplateResult {
+    const param = this._getParameter();
+    return html`<div id="root">
+      <sl-button-group label="statue">
+        <sl-button
+          size="medium"
+          variant="${param.variant}"
+          id="status-button"
+          ?disabled=${this._isDone}
+          @click=${this._handleClickStatusButton}
+        >
+          <sl-icon library="taskit" name=${param.icon} slot="prefix"></sl-icon>
+          ${param.label}
+        </sl-button>
+        ${this._isDone
+          ? html`<sl-dropdown>
+              <sl-button
+                variant="${param.variant}"
+                size="medium"
+                slot="trigger"
+                caret
+              >
+              </sl-button>
+              <sl-menu>
+                <sl-menu-item @click=${this._handleClickStatusButton}>
+                  <sl-icon
+                    library="taskit"
+                    name="arrow-clockwise"
+                    slot="prefix"
+                  ></sl-icon>
+                  再開
+                </sl-menu-item>
+              </sl-menu>
+            </sl-dropdown>`
+          : ``}
+      </sl-button-group>
+    </div>`;
+  }
+
+  /**
+   * 現在のタスクステータスに応じたUI表示用パラメータ（スタイル、ラベル、アイコン）を取得します。
+   *
+   * @private
+   * @returns {TaskParameter} 各ステータスに対応する表示設定オブジェクト
+   */
+  private _getParameter(): ObjectParameter {
+    switch (this.status) {
+      case TASK_STATUS.PENDING.code:
+        return {
+          variant: "primary",
+          label: "開始",
+          icon: "play-circle-fill",
+        };
+      case TASK_STATUS.PROGRESS.code:
+        return {
+          variant: "success",
+          label: "完了",
+          icon: "check-circle-fill",
+        };
+      case TASK_STATUS.DONE.code:
+        return {
+          variant: "neutral",
+          label: "済",
+          icon: "slash-circle-fill",
+        };
+      default:
+        return {
+          variant: "neutral",
+          label: "-",
+          icon: "",
+        };
+    }
+  }
+
+  /**
+   * ボタン要素の参照を取得します。
+   *
+   * @private
+   * @type {HTMLElement}
+   * @memberof TiStatusButton
+   */
+  @query("#status-button") private _statusButton!: HTMLElement;
+
+  /**
+   * ステータス更新ボタンのクリックイベントをハンドリングします。
+   * * 現在のステータスに基づいて次の遷移先ステータスを決定し、
+   * `ti-change-status` イベントを介して外部へ通知します。
+   * * @private
+   * @fires ti-change-status - 更新後のステータスコードを detail に含めて発火
+   */
+  private _handleClickStatusButton(): void {
+    // ボタンからフォーカスを外す（disabled 遷移時の Lit/Shoelace の競合を防止）
+    if (this._statusButton) {
+      (this._statusButton as any).blur();
+    }
+
+    let nextStatus: string;
+    switch (this.status) {
+      case TASK_STATUS.PENDING.code:
+        nextStatus = TASK_STATUS.PROGRESS.code;
+        break;
+      case TASK_STATUS.PROGRESS.code:
+        nextStatus = TASK_STATUS.DONE.code;
+        break;
+      case TASK_STATUS.DONE.code:
+        // 完了済みの場合は前の状態に戻す
+        nextStatus = TASK_STATUS.PROGRESS.code;
+        break;
+      default:
+        nextStatus = TASK_STATUS.PROGRESS.code;
+    }
+    emit(this, "ti-change-status", { detail: nextStatus });
+  }
+}

--- a/src/components/ti-taskdata/ti-task-data.lit.scss
+++ b/src/components/ti-taskdata/ti-task-data.lit.scss
@@ -16,16 +16,13 @@
 
   .header-area {
     grid-area: header-area;
+    display: grid;
+    grid-template-columns: 1fr 180px;
 
     .title {
       padding: 0 var(--sl-spacing-3x-small);
-      display: flex;
-      flex-direction: row;
-      align-items: flex-end;
-      gap: 5px;
 
       sl-input {
-        flex: 1 1 auto;
         width: 100%;
 
         &::part(base) {
@@ -37,16 +34,16 @@
           padding: var(--sl-spacing-2x-small);
           margin-top: 5px;
           height: 45px;
-          font-size: var(--sl-font-size-2x-large);
+          font-size: var(--sl-font-size-large);
           font-weight: bold;
         }
       }
+    }
 
-      sl-button {
-        flex: 0 0 90px;
-
-        width: 90px;
-      }
+    .button {
+      display: flex;
+      align-items: flex-end;
+      justify-content: right;
     }
   }
 

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -162,11 +162,13 @@ export class TiTaskData extends LitElement {
    * @param {PropertyValues} _changedProperties
    * @memberof TiTaskData
    */
-  protected async willUpdate(_changedProperties: PropertyValues) {
+  protected willUpdate(_changedProperties: PropertyValues) {
     super.willUpdate(_changedProperties);
     if (_changedProperties.has("taskId")) {
       if (this.taskId !== undefined) {
-        this._taskData = await db.getTaskById(this.taskId);
+        db.getTaskById(this.taskId).then((task) => {
+          this._taskData = task;
+        });
       } else {
         this._taskData = undefined;
       }
@@ -187,8 +189,9 @@ export class TiTaskData extends LitElement {
       return html``;
     }
     return html`<div class="container">
-      <!--タイトル-->
+      <!--ヘッダー-->
       <div class="header-area">
+        <!--タイトル-->
         <div class="title">
           <sl-input
             id="title"
@@ -198,17 +201,17 @@ export class TiTaskData extends LitElement {
             value=${this._taskData?.title}
             @sl-change=${this._handleChangeTitle}
           ></sl-input>
-          <sl-button size="medium" variant="primary" class="title-item">
-            <sl-icon
-              library="taskit"
-              name="play-circle-fill"
-              slot="prefix"
-            ></sl-icon>
-            開始
-          </sl-button>
+        </div>
+        <div class="button">
+          <!--ステータスボタン-->
+          <ti-status-button
+            .status=${this._taskData?.status}
+            @ti-change-status=${this._handleChangeStatus}
+          >
+          </ti-status-button>
         </div>
       </div>
-      <!--コントロールボタン-->
+      <!--ｘｘｘ-->
       <div class="control-area"></div>
       <div class="base main-area">
         <sl-tab-group>
@@ -248,8 +251,8 @@ export class TiTaskData extends LitElement {
                 <ti-input-label
                   .label=${"関係者"}
                   .icon=${"people"}
-                  .editable=${true}
-                  .addable=${true}
+                  .isEditable=${true}
+                  .isAddable=${true}
                   @ti-edit=${this._handleClickEditMember}
                   @ti-add=${this._addMember}
                 ></ti-input-label>
@@ -286,8 +289,8 @@ export class TiTaskData extends LitElement {
                 <ti-input-label
                   .label=${"リスト一覧"}
                   .icon=${"ui-checks-grid"}
-                  .editable=${true}
-                  .addable=${true}
+                  .isEditable=${true}
+                  .isAddable=${true}
                   @ti-edit=${this._handleClickCheckListEdit}
                   @ti-add=${this._addChecklist}
                 ></ti-input-label>
@@ -376,6 +379,14 @@ export class TiTaskData extends LitElement {
     </div>`;
   }
 
+  private _handleChangeStatus(e: CustomEvent): void {
+    if (!this._taskData) {
+      return;
+    }
+    this._taskData = { ...this._taskData, status: e.detail };
+    this._updateTaskData();
+  }
+
   /**
    * タイトルの変更入力を検知しDBを更新する。
    *
@@ -386,7 +397,7 @@ export class TiTaskData extends LitElement {
     if (!this._taskData) {
       return;
     }
-    this._taskData.title = this._titleInput.value;
+    this._taskData = { ...this._taskData, title: this._titleInput.value };
     this._updateTaskData();
   }
 
@@ -397,16 +408,12 @@ export class TiTaskData extends LitElement {
    * @returns {*}
    */
   private _handleChangeDueDate(): void {
-    if (!this._taskData) {
-      return;
-    }
+    if (!this._taskData || !this._dueDateInput.value) return;
 
-    const dueDateValue = this._dueDateInput.value;
-    if (!dueDateValue) {
-      return;
-    }
-
-    this._taskData.dueDate = new Date(dueDateValue);
+    this._taskData = {
+      ...this._taskData,
+      dueDate: new Date(this._dueDateInput.value),
+    };
     this._updateTaskData();
   }
 
@@ -418,10 +425,12 @@ export class TiTaskData extends LitElement {
    * @memberof TiTaskData
    * */
   private _handleChangeDescription(): void {
-    if (!this._taskData) {
-      return;
-    }
-    this._taskData.description = this._descriptionTextarea.value;
+    if (!this._taskData) return;
+
+    this._taskData = {
+      ...this._taskData,
+      description: this._descriptionTextarea.value,
+    };
     this._updateTaskData();
   }
 
@@ -433,11 +442,13 @@ export class TiTaskData extends LitElement {
    * @memberof TiTaskData
    */
   private async _updateTaskData(): Promise<void> {
-    if (!this._taskData) {
-      return;
+    if (!this._taskData) return;
+
+    try {
+      await db.updateTask(this._taskData);
+    } catch (error) {
+      console.error("Failed to update task:", error);
     }
-    db.updateTask(this._taskData);
-    this._taskData = await db.getTaskById(this._taskData.id!);
   }
 
   /**
@@ -457,19 +468,13 @@ export class TiTaskData extends LitElement {
    * @memberof TiTaskData
    */
   private _addMember(): void {
-    if (!this._taskData) {
-      return;
-    }
+    if (!this._taskData) return;
 
-    if (this._taskData && !this._taskData.members) {
-      this._taskData.members = [];
-    }
-
-    this._taskData.members.push({
-      div: "",
-      name: "",
-      tel: "",
-    });
+    const currentMembers = this._taskData.members || [];
+    this._taskData = {
+      ...this._taskData,
+      members: [...currentMembers, { div: "", name: "", tel: "" }], // 新しい配列を作成
+    };
     this._updateTaskData();
   }
 
@@ -480,8 +485,11 @@ export class TiTaskData extends LitElement {
    * @memberof TiTaskData
    */
   private _handleChangeMembers(e: CustomEvent): void {
-    this._taskData!.members = e.detail;
-    if (this._taskData?.members.length === 0) {
+    if (!this._taskData) return;
+
+    this._taskData = { ...this._taskData, members: e.detail };
+
+    if (this._taskData.members.length === 0) {
       this._isMemberEditMode = false;
     }
     this._updateTaskData();
@@ -526,20 +534,13 @@ export class TiTaskData extends LitElement {
    * @memberof TiInputLabel
    */
   private _addChecklist(): void {
-    if (!this._taskData) {
-      return;
-    }
+    if (!this._taskData) return;
 
-    // checklist が未定義の場合は空配列で初期化
-    if (this._taskData && !this._taskData.checklist) {
-      this._taskData.checklist = [];
-    }
-
-    this._taskData.checklist.push({
-      label: "",
-      checkboxes: [],
-    });
-
+    const currentChecklist = this._taskData.checklist || [];
+    this._taskData = {
+      ...this._taskData,
+      checklist: [...currentChecklist, { label: "", checkboxes: [] }],
+    };
     this._updateTaskData();
   }
 
@@ -553,13 +554,19 @@ export class TiTaskData extends LitElement {
    * @returns {*}
    **/
   private _saveCheckBoxes(e: CustomEvent, index: number): void {
-    if (!this._taskData || !this._taskData.checklist) {
-      return;
-    }
+    if (!this._taskData || !this._taskData.checklist) return;
 
-    // イベントから受け取った label と checkboxes を該当のチェックリストに反映する
-    this._taskData.checklist[index].checkboxes = e.detail.checkboxes;
+    // 1. 配列をコピー
+    const newChecklist = [...this._taskData.checklist];
 
+    // 2. 該当するインデックスのオブジェクトも新しく作り直す
+    newChecklist[index] = {
+      ...newChecklist[index],
+      checkboxes: e.detail.checkboxes,
+    };
+
+    // 3. 親オブジェクトにセット
+    this._taskData = { ...this._taskData, checklist: newChecklist };
     this._updateTaskData();
   }
 
@@ -582,10 +589,19 @@ export class TiTaskData extends LitElement {
    * @return {*}
    */
   private _handleChangeUrl(e: CustomEvent): void {
-    this._taskData!.urls = e.detail;
-    if (this._taskData?.urls.length === 0) {
+    if (!this._taskData) return;
+
+    // 新しいオブジェクトを作成し、urlsプロパティのみe.detailで上書き
+    this._taskData = {
+      ...this._taskData,
+      urls: e.detail,
+    };
+
+    // リンクが空になったら編集モードをオフにする
+    if (this._taskData.urls.length === 0) {
       this._isUrlEditMode = false;
     }
+
     this._updateTaskData();
   }
 
@@ -608,10 +624,19 @@ export class TiTaskData extends LitElement {
    * @return {*}
    */
   private _handleChangeFolder(e: CustomEvent): void {
-    this._taskData!.folders = e.detail;
-    if (this._taskData?.folders.length === 0) {
+    if (!this._taskData) return;
+
+    // 新しいオブジェクトを作成し、foldersプロパティのみ上書き
+    this._taskData = {
+      ...this._taskData,
+      folders: e.detail,
+    };
+
+    // フォルダが空になったら編集モードをオフにする
+    if (this._taskData.folders.length === 0) {
       this._isFolderEditMode = false;
     }
+
     this._updateTaskData();
   }
 }

--- a/src/plugins/shoelace.ts
+++ b/src/plugins/shoelace.ts
@@ -4,6 +4,7 @@ import "@shoelace-style/shoelace/dist/components/button-group/button-group.js";
 import "@shoelace-style/shoelace/dist/components/checkbox/checkbox.js";
 import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
 import "@shoelace-style/shoelace/dist/components/divider/divider.js";
+import "@shoelace-style/shoelace/dist/components/dropdown/dropdown.js";
 import "@shoelace-style/shoelace/dist/components/icon/icon.js";
 import "@shoelace-style/shoelace/dist/components/input/input.js";
 import "@shoelace-style/shoelace/dist/components/icon-button/icon-button.js";


### PR DESCRIPTION
- 新しいアイコンを追加: arrow-clockwise, check-circle-fill, slash-circle-fill
- ti-status-buttonコンポーネントを作成し、タスクのステータスを表示・変更できる機能を実装
- ti-task-dataコンポーネントにステータスボタンを統合
- スタイルを調整し、UIの一貫性を向上
- shoelaceプラグインにドロップダウンコンポーネントを追加