### PR TITLE
feat: #50 タスク選択機能の追加とスタイルの改善

### DIFF
--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -379,11 +379,21 @@ export class TiTaskData extends LitElement {
     </div>`;
   }
 
+  /**
+   * ステータス変更イベントをハンドルし、タスクデータを更新します。
+   * * @private
+   * @param {CustomEvent} e - ステータス変更イベント。`e.detail` に新しいステータスコードが含まれていることを期待します。
+   * @description
+   * 1. 既存のタスクデータが存在しない場合は処理を中断します。
+   * 2. 現在のタスクデータをコピーし、ステータスのみを新しい値で上書き（イミュータブルな更新）します。
+   * 3. 最後に `_updateTaskData()` を呼び出し、変更を外部や永続化層へ反映させます。
+   */
   private _handleChangeStatus(e: CustomEvent): void {
     if (!this._taskData) {
       return;
     }
-    this._taskData = { ...this._taskData, status: e.detail };
+    const newStatus = e.detail;
+    this._taskData = { ...this._taskData, status: newStatus };
     this._updateTaskData();
   }
 

--- a/src/components/ti-taskitem/ti-taskitem.lit.scss
+++ b/src/components/ti-taskitem/ti-taskitem.lit.scss
@@ -6,10 +6,6 @@
   display: flex;
   flex-direction: row;
 
-  &:hover {
-    background-color: var(--sl-color-neutral-200);
-  }
-
   .label {
     flex: 1 1 auto;
 
@@ -20,12 +16,6 @@
 
     padding: 1px var(--sl-spacing-2x-small);
     padding-right: 0;
-
-    &:hover {
-      color: var(--sl-color-primary-800);
-      text-decoration: underline;
-      font-weight: bold;
-    }
 
     .task-title {
       margin-top: -1px;
@@ -44,5 +34,30 @@
 
   .icon {
     flex: 0 0 auto;
+  }
+
+  &.selected {
+    background-color: var(--sl-color-primary-600);
+    color: #fffff0;
+
+    .overdue {
+      color: #fffff0;
+    }
+
+    sl-dropdown {
+      .icon {
+        color: #fffff0;
+      }
+    }
+  }
+
+  &:hover {
+    background-color: var(--sl-color-neutral-200);
+
+    .label {
+      color: var(--sl-color-primary-800);
+      text-decoration: underline;
+      font-weight: bold;
+    }
   }
 }

--- a/src/components/ti-taskitem/ti-taskitem.ts
+++ b/src/components/ti-taskitem/ti-taskitem.ts
@@ -45,6 +45,14 @@ export class TiTaskItem extends LitElement {
   @property({ type: Date }) dueDate?: Date;
 
   /**
+   * 選択中であるかを示す
+   *
+   * @type {boolean}
+   * @memberof TiTaskItem
+   */
+  @property({ type: Boolean }) isSelected: boolean = false;
+
+  /**
    * ツールチップに表示するタスク名
    *
    * @type {string}
@@ -124,7 +132,7 @@ export class TiTaskItem extends LitElement {
       overdue: isOverdue,
     };
 
-    return html`<div id="root">
+    return html`<div id="root" class="${this.isSelected ? "selected" : ""}">
       <sl-tooltip placement="right">
         <div class="${classMap(classes)}">
           <sl-icon

--- a/src/components/ti-tasklist/ti-tasklist.ts
+++ b/src/components/ti-tasklist/ti-tasklist.ts
@@ -7,7 +7,7 @@ import {
   HTMLTemplateResult,
 } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import { customElement, state, query } from "lit/decorators.js";
+import { customElement, state, property, query } from "lit/decorators.js";
 import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
 import { db } from "@/service/TaskItDB";
 import { TASK_STATUS, type Task } from "@/models/Task";
@@ -36,6 +36,22 @@ export class TiTaskList extends LitElement {
       ${unsafeCSS(styles)}
     `,
   ];
+
+  /**
+   * 選択中タスクのID
+   *
+   * @type {number}
+   * @memberof TiTaskList
+   */
+  @property({ type: Number }) selectedTaskId?: number;
+
+  /**
+   * 選択中のタブのID
+   *
+   * @type {number}
+   * @memberof TiTaskList
+   */
+  @property({ type: Number }) selectedTabId?: string;
 
   /**
    * タスク名入力ダイアログ
@@ -131,6 +147,24 @@ export class TiTaskList extends LitElement {
   }
 
   /**
+   * render完了後に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TaskitApp
+   */
+  updated(_changedProperties: PropertyValues) {
+    if (
+      _changedProperties.has("selectedTabId") &&
+      this.selectedTabId !== undefined
+    ) {
+      requestAnimationFrame(() => {
+        this.selectedTabId = undefined;
+      });
+    }
+  }
+
+  /**
    * コンポーネントのメインレイアウトをレンダリングします。
    * アプリケーションの基本構造を定義します。
    *
@@ -142,15 +176,15 @@ export class TiTaskList extends LitElement {
   protected render(): HTMLTemplateResult {
     return html` <div id="root">
       <sl-tab-group>
-        <sl-tab slot="nav" panel="pending">
+        <sl-tab slot="nav" panel="pending" ?active=${this._isActive(TASK_STATUS.PENDING.code)}>
           <sl-icon library="taskit" name="square"></sl-icon>
           <span>未着手</span>
         </sl-tab>
-        <sl-tab slot="nav" panel="progress">
+        <sl-tab slot="nav" panel="progress" ?active=${this._isActive(TASK_STATUS.PROGRESS.code)}>
           <sl-icon library="taskit" name="square-half"></sl-icon>
           <span>実行中</span>
         </sl-tab>
-        <sl-tab slot="nav" panel="done">
+        <sl-tab slot="nav" panel="done" ?active=${this._isActive(TASK_STATUS.DONE.code)}>
           <sl-icon library="taskit" name="check-square"></sl-icon>
           <span>完了</span>
         </sl-tab>
@@ -161,7 +195,11 @@ export class TiTaskList extends LitElement {
               this._pendingTasks,
               (task) => task.id,
               (task) => html`
-                <ti-taskitem .taskId=${task.id} .dueDate=${task.dueDate}>
+                <ti-taskitem
+                  .taskId=${task.id}
+                  .dueDate=${task.dueDate}
+                  .isSelected=${task.id === this.selectedTaskId}
+                >
                   ${task.title}
                 </ti-taskitem>
               `,
@@ -174,7 +212,13 @@ export class TiTaskList extends LitElement {
               this._progressTasks,
               (task) => task.id,
               (task) => html`
-                <ti-taskitem .task=${task}>${task.title}</ti-taskitem>
+                <ti-taskitem
+                  .taskId=${task.id}
+                  .dueDate=${task.dueDate}
+                  .isSelected=${task.id === this.selectedTaskId}
+                >
+                  ${task.title}
+                </ti-taskitem>
               `,
             )}
           </div>
@@ -185,7 +229,13 @@ export class TiTaskList extends LitElement {
               this._doneTasks,
               (task) => task.id,
               (task) => html`
-                <ti-taskitem .task=${task}>${task.title}</ti-taskitem>
+                <ti-taskitem
+                  .taskId=${task.id}
+                  .dueDate=${task.dueDate}
+                  .isSelected=${task.id === this.selectedTaskId}
+                >
+                  ${task.title}
+                </ti-taskitem>
               `,
             )}
           </div>
@@ -221,6 +271,16 @@ export class TiTaskList extends LitElement {
         </sl-dialog>
       </div>
     </div>`;
+  }
+
+  /**
+   * タブがアクティベート対象であるかチェックします。
+   *
+   * @param code
+   * @returns
+   */
+  private _isActive(code: string): boolean {
+    return code === this.selectedTabId;
   }
 
   /**

--- a/src/taskit-app.ts
+++ b/src/taskit-app.ts
@@ -39,6 +39,14 @@ export class TaskitApp extends LitElement {
   @state() selectedTaskId?: number = undefined;
 
   /**
+   * 選択中のタブID
+   *
+   * @type {number}
+   * @memberof TaskitApp
+   */
+  @state() selectedTabId?: string = undefined;
+
+  /**
    * Creates an instance of TaskitApp.
    * @memberof TaskitApp
    */
@@ -88,6 +96,24 @@ export class TaskitApp extends LitElement {
   }
 
   /**
+   * render完了後に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TaskitApp
+   */
+  updated(_changedProperties: PropertyValues) {
+    if (
+      _changedProperties.has("selectedTabId") &&
+      this.selectedTabId !== undefined
+    ) {
+      requestAnimationFrame(() => {
+        this.selectedTabId = undefined;
+      });
+    }
+  }
+
+  /**
    * コンポーネントのメインレイアウトをレンダリングします。
    * アプリケーションの基本構造を定義します。
    *
@@ -101,11 +127,17 @@ export class TaskitApp extends LitElement {
       <div class="header-area"></div>
       <div class="menu-area">
         <ti-tasklist
+          .selectedTaskId=${this.selectedTaskId}
+          .selectedTabId=${this.selectedTabId}
           @ti-taskitem-click=${this._handleTiClickTaskItem}
         ></ti-tasklist>
       </div>
       <div class="contents1-area">
-        <ti-task-data .taskId=${this.selectedTaskId}></ti-task-data>
+        <ti-task-data
+          .taskId=${this.selectedTaskId}
+          @ti-change-status=${this._handleChangeStatus}
+        >
+        </ti-task-data>
       </div>
       <div class="footer-area"></div>
     </div>`;
@@ -120,5 +152,16 @@ export class TaskitApp extends LitElement {
    */
   private _handleTiClickTaskItem(e: CustomEvent) {
     this.selectedTaskId = e.detail.taskId;
+  }
+
+  /**
+   * タスク画面で選択したステータス（タブ）を選択状態とする。
+   *
+   * @private
+   * @param {CustomEvent} e
+   * @memberof TaskitApp
+   */
+  private _handleChangeStatus(e: CustomEvent) {
+    this.selectedTabId = e.detail;
   }
 }


### PR DESCRIPTION
- TiTaskData: ステータス変更イベントをハンドルし、タスクデータを更新するメソッドを追加
- TiTaskItem: 選択状態を示すプロパティを追加し、選択時のスタイルを適用
- TiTaskList: 選択中のタスクIDとタブIDを管理するプロパティを追加し、タスクアイテムに選択状態を反映
- taskit-app: 選択中のタブIDを管理し、タスクデータコンポーネントにステータス変更イベントを追加