### PR TITLE
feat: #53 ステータスタグコンポーネントの追加とレイアウト調整

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from "@/components/ti-checkboxes/ti-checkboxes";
 export * from "@/components/ti-link/ti-link";
 export * from "@/components/ti-input-label/ti-input-label";
 export * from "@/components/ti-status-button/ti-status-button";
+export * from "@/components/ti-status-tag/ti-status-tag";

--- a/src/components/ti-status-button/ti-status-button.ts
+++ b/src/components/ti-status-button/ti-status-button.ts
@@ -169,7 +169,7 @@ export class TiStatusButton extends LitElement {
       case TASK_STATUS.DONE.code:
         return {
           variant: "neutral",
-          label: "済",
+          label: "-",
           icon: "slash-circle-fill",
         };
       default:

--- a/src/components/ti-status-tag/ti-status-tag.lit.scss
+++ b/src/components/ti-status-tag/ti-status-tag.lit.scss
@@ -1,0 +1,28 @@
+.status-label {
+  width: 35px;
+  padding: var(--sl-spacing-small) var(--sl-spacing-x-small);
+  border-radius: 1.2rem;
+
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+
+  span {
+    margin-top: -2px;
+  }
+
+  color: #fffff0;
+  font-weight: bold;
+  font-size: var(--sl-font-size-small);
+
+  &.neutral {
+    background-color: var(--sl-color-neutral-600);
+  }
+  &.primary {
+    background-color: var(--sl-color-primary-600);
+  }
+  &.success {
+    background-color: var(--sl-color-success-600);
+  }
+}

--- a/src/components/ti-status-tag/ti-status-tag.ts
+++ b/src/components/ti-status-tag/ti-status-tag.ts
@@ -1,0 +1,132 @@
+import {
+  LitElement,
+  html,
+  css,
+  unsafeCSS,
+  PropertyValues,
+  HTMLTemplateResult,
+} from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path.js";
+import { TASK_STATUS } from "@/models/Task";
+
+import "@shoelace-style/shoelace/dist/themes/light.css";
+import styles from "./ti-status-tag.lit.scss?inline";
+
+/**
+ * UI表示に必要なパラメータの型定義
+ */
+interface ObjectParameter {
+  /** ボタンやバッジのスタイル指定（CSSクラス等に使用） */
+  variant: string;
+  /** アイコンフォントのクラス名や識別子 */
+  icon: string;
+}
+
+setBasePath("/");
+@customElement("ti-status-tag")
+export class TiStatusTag extends LitElement {
+  /**
+   * スタイルシートを適用
+   *
+   * @static
+   * @memberof TiStatusTag
+   */
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  /**
+   * タスクのステータス状態
+   *
+   * @type {number}
+   * @memberof TiTaskData
+   */
+  @property({ type: String }) status?: string;
+
+  /**
+   * Creates an instance of TiStatusTag.
+   * @memberof TiStatusTag
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM に追加されたときに実行されます。
+   *
+   * @override
+   * @memberof TiStatusTag
+   */
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  /**
+   * コンポーネントがドキュメントの DOM から削除されたときに実行されます。
+   *
+   * @override
+   * @memberof TiStatusTag
+   */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  /**
+   * render直前に実行されます。
+   *
+   * @protected
+   * @param {PropertyValues} _changedProperties
+   * @memberof TiStatusTag
+   */
+  protected willUpdate(_changedProperties: PropertyValues) {
+    super.willUpdate(_changedProperties);
+  }
+
+  /**
+   * コンポーネントのメインレイアウトをレンダリングします。
+   * アプリケーションの基本構造を定義します。
+   *
+   * @protected
+   * @override
+   * @returns {HTMLTemplateResult} レンダリングされる Lit テンプレート
+   * @memberof TiStatusTag
+   */
+  protected render(): HTMLTemplateResult {
+    const param = this._getParameter();
+    return html`<div class="status-label ${param.variant}" size="medium">
+      <sl-icon library="taskit" name="${param.icon}"></sl-icon>
+    </div>`;
+  }
+
+  /**
+   * 現在のタスクステータスに応じたUI表示用パラメータ（スタイル、ラベル、アイコン）を取得します。
+   *
+   * @private
+   * @returns {TaskParameter} 各ステータスに対応する表示設定オブジェクト
+   */
+  private _getParameter(): ObjectParameter {
+    switch (this.status) {
+      case TASK_STATUS.PENDING.code:
+        return {
+          variant: "neutral",
+          icon: "square",
+        };
+      case TASK_STATUS.PROGRESS.code:
+        return {
+          variant: "primary",
+          icon: "square-half",
+        };
+      case TASK_STATUS.DONE.code:
+        return {
+          variant: "success",
+          icon: "check-square",
+        };
+      default:
+        return {
+          variant: "neutral",
+          icon: "",
+        };
+    }
+  }
+}

--- a/src/components/ti-taskdata/ti-task-data.lit.scss
+++ b/src/components/ti-taskdata/ti-task-data.lit.scss
@@ -40,7 +40,7 @@
       }
     }
 
-    .button {
+    .label {
       display: flex;
       align-items: flex-end;
       justify-content: right;
@@ -49,7 +49,10 @@
 
   .control-area {
     grid-area: control-area;
-    background-color: burlywood;
+    padding-right: var(--sl-spacing-x-small);
+    display: flex;
+    align-items: flex-end;
+    justify-content: right;
   }
 
   .main-area {

--- a/src/components/ti-taskdata/ti-task-data.ts
+++ b/src/components/ti-taskdata/ti-task-data.ts
@@ -202,17 +202,19 @@ export class TiTaskData extends LitElement {
             @sl-change=${this._handleChangeTitle}
           ></sl-input>
         </div>
-        <div class="button">
-          <!--ステータスボタン-->
-          <ti-status-button
-            .status=${this._taskData?.status}
-            @ti-change-status=${this._handleChangeStatus}
-          >
-          </ti-status-button>
+        <div class="label">
+          <ti-status-tag .status=${this._taskData?.status}></ti-status-tag>
         </div>
       </div>
-      <!--ｘｘｘ-->
-      <div class="control-area"></div>
+      <!--コントロール-->
+      <div class="control-area">
+        <!--ステータスボタン-->
+        <ti-status-button
+          .status=${this._taskData?.status}
+          @ti-change-status=${this._handleChangeStatus}
+        >
+        </ti-status-button>
+      </div>
       <div class="base main-area">
         <sl-tab-group>
           <sl-tab slot="nav" panel="summary">

--- a/src/plugins/shoelace.ts
+++ b/src/plugins/shoelace.ts
@@ -11,6 +11,7 @@ import "@shoelace-style/shoelace/dist/components/icon-button/icon-button.js";
 import "@shoelace-style/shoelace/dist/components/radio-group/radio-group.js";
 import "@shoelace-style/shoelace/dist/components/radio-button/radio-button.js";
 import "@shoelace-style/shoelace/dist/components/tab/tab.js";
+import "@shoelace-style/shoelace/dist/components/tag/tag.js";
 import "@shoelace-style/shoelace/dist/components/tab-group/tab-group.js";
 import "@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js";
 import "@shoelace-style/shoelace/dist/components/textarea/textarea.js";


### PR DESCRIPTION
- ti-status-tagコンポーネントを新規作成し、タスクのステータス表示を実装
- ti-status-tagのスタイルをti-status-tag.lit.scssに定義
- ti-status-buttonのラベルを「済」から「-」に変更
- ti-task-dataコンポーネント内でステータスボタンをステータスタグに置き換え
- ti-task-dataのスタイルを調整し、ラベルクラスを追加
- shoelaceプラグインにタグコンポーネントをインポート